### PR TITLE
Add syntax highlighting for code blocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ from Github.
 As Sami uses Composer to manage its dependencies, installing it is a matter of
 running composer:
 
-    $ composer.phar install
+```sh
+$ composer.phar install
+```
 
 Check that everything worked as expected by executing the `sami.php` file
 without any arguments:
 
-    $ php sami.php
+```sh
+$ php sami.php
+```
 
 Configuration
 -------------
@@ -33,9 +37,11 @@ Configuration
 Before generating documentation, you must create a configuration file. Here is
 the simplest possible one:
 
-    <?php
+```php
+<?php
 
-    return new Sami\Sami('/path/to/symfony/src');
+return new Sami\Sami('/path/to/symfony/src');
+```
 
 The configuration file must return an instance of `Sami\Sami` and the first
 argument of the constructor is the path to the code you want to generate
@@ -45,63 +51,71 @@ Actually, instead of a directory, you can use any valid PHP iterator (and for
 that matter any instance of the Symfony
 [Finder](http://symfony.com/doc/current/components/finder.html) class):
 
-    <?php
+```php
+<?php
 
-    use Sami\Sami;
-    use Symfony\Component\Finder\Finder;
+use Sami\Sami;
+use Symfony\Component\Finder\Finder;
 
-    $iterator = Finder::create()
-        ->files()
-        ->name('*.php')
-        ->exclude('Resources')
-        ->exclude('Tests')
-        ->in('/path/to/symfony/src')
-    ;
+$iterator = Finder::create()
+    ->files()
+    ->name('*.php')
+    ->exclude('Resources')
+    ->exclude('Tests')
+    ->in('/path/to/symfony/src')
+;
 
-    return new Sami($iterator);
+return new Sami($iterator);
+```
 
 The `Sami` constructor optionally takes an array of options as a second
 argument:
 
-    return new Sami($iterator, array(
-        'theme'                => 'symfony',
-        'title'                => 'Symfony2 API',
-        'build_dir'            => __DIR__.'/build',
-        'cache_dir'            => __DIR__.'/cache',
-        'default_opened_level' => 2,
-    ));
+```php
+<?php
+
+return new Sami($iterator, array(
+    'theme'                => 'symfony',
+    'title'                => 'Symfony2 API',
+    'build_dir'            => __DIR__.'/build',
+    'cache_dir'            => __DIR__.'/cache',
+    'default_opened_level' => 2,
+));
+```
 
 And here is how you can configure different versions:
 
-    <?php
+```php
+<?php
 
-    use Sami\Sami;
-    use Sami\Version\GitVersionCollection;
-    use Symfony\Component\Finder\Finder;
+use Sami\Sami;
+use Sami\Version\GitVersionCollection;
+use Symfony\Component\Finder\Finder;
 
-    $iterator = Finder::create()
-        ->files()
-        ->name('*.php')
-        ->exclude('Resources')
-        ->exclude('Tests')
-        ->in($dir = '/path/to/symfony/src')
-    ;
+$iterator = Finder::create()
+    ->files()
+    ->name('*.php')
+    ->exclude('Resources')
+    ->exclude('Tests')
+    ->in($dir = '/path/to/symfony/src')
+;
 
-    // generate documentation for all v2.0.* tags, the 2.0 branch, and the master one
-    $versions = GitVersionCollection::create($dir)
-        ->addFromTags('v2.0.*')
-        ->add('2.0', '2.0 branch')
-        ->add('master', 'master branch')
-    ;
+// generate documentation for all v2.0.* tags, the 2.0 branch, and the master one
+$versions = GitVersionCollection::create($dir)
+    ->addFromTags('v2.0.*')
+    ->add('2.0', '2.0 branch')
+    ->add('master', 'master branch')
+;
 
-    return new Sami($iterator, array(
-        'theme'                => 'symfony',
-        'versions'             => $versions,
-        'title'                => 'Symfony2 API',
-        'build_dir'            => __DIR__.'/../build/sf2/%version%',
-        'cache_dir'            => __DIR__.'/../cache/sf2/%version%',
-        'default_opened_level' => 2,
-    ));
+return new Sami($iterator, array(
+    'theme'                => 'symfony',
+    'versions'             => $versions,
+    'title'                => 'Symfony2 API',
+    'build_dir'            => __DIR__.'/../build/sf2/%version%',
+    'cache_dir'            => __DIR__.'/../cache/sf2/%version%',
+    'default_opened_level' => 2,
+));
+```
 
 To generate documentation for a PHP 5.2 project, simply set the
 `simulate_namespaces` option to `true`.
@@ -114,7 +128,9 @@ Rendering
 
 Now that we have a configuration file, let's generate the API documentation:
 
-    $ php sami.php update /path/to/config.php
+```sh
+$ php sami.php update /path/to/config.php
+```
 
 The generated documentation can be found under the configured `build/`
 directory (note that the client side search engine does not work on Chrome due
@@ -127,7 +143,9 @@ to be updated based on what has changed in your code since the last execution.
 Sami also detects problems in your phpdoc and can tell you what you need to
 fix if you add the `-v` option:
 
-    $ php sami.php update /path/to/config.php -v
+```sh
+$ php sami.php update /path/to/config.php -v
+```
 
 Creating a Theme
 ----------------
@@ -138,19 +156,23 @@ one, or just override an existing one.
 A theme is just a directory with a `manifest.yml` file that describes the
 theme (this is a YAML file):
 
-    name:   symfony
-    parent: enhanced
+```yaml
+name:   symfony
+parent: enhanced
+```
 
 The above configuration creates a new `symfony` theme based on the `enhanced`
 built-in theme. To override a template, just create a file with the same name
 as the original one. For instance, here is how you can extend the default
 class template to prefix the class name with "Class " in the class page title:
 
-    {# pages/class.twig #}
+```jinja
+{# pages/class.twig #}
 
-    {% extends 'default/pages/class.twig' %}
+{% extends 'default/pages/class.twig' %}
 
-    {% block title %}Class {{ parent() }}{% endblock %}
+{% block title %}Class {{ parent() }}{% endblock %}
+```
 
 If you are familiar with Twig, you will be able to very easily tweak every
 aspect of the templates as everything has been well isolated in named Twig
@@ -159,27 +181,29 @@ blocks.
 A theme can also add more templates and static files. Here is the manifest for
 the default theme:
 
-    name: default
+```yaml
+name: default
 
-    static:
-        'stylesheet.css':        'stylesheet.css'
+static:
+    'stylesheet.css':        'stylesheet.css'
 
-    global:
-        'index.twig':            'index.html'
-        'namespaces.twig':       'namespaces-frame.html'
-        'classes.twig':          'classes-frame.html'
-        'pages/opensearch.twig': 'opensearch.xml'
-        'pages/index.twig':      'doc-index.html'
-        'pages/namespaces.twig': 'namespaces.html'
-        'pages/interfaces.twig': 'interfaces.html'
-        'pages/classes.twig':    'classes.html'
+global:
+    'index.twig':            'index.html'
+    'namespaces.twig':       'namespaces-frame.html'
+    'classes.twig':          'classes-frame.html'
+    'pages/opensearch.twig': 'opensearch.xml'
+    'pages/index.twig':      'doc-index.html'
+    'pages/namespaces.twig': 'namespaces.html'
+    'pages/interfaces.twig': 'interfaces.html'
+    'pages/classes.twig':    'classes.html'
 
-    namespace:
-        'namespace.twig':        '%s/namespace-frame.html'
-        'pages/namespace.twig':  '%s.html'
+namespace:
+    'namespace.twig':        '%s/namespace-frame.html'
+    'pages/namespace.twig':  '%s.html'
 
-    class:
-        'pages/class.twig':      '%s.html'
+class:
+    'pages/class.twig':      '%s.html'
+```
 
 Files are contained into sections, depending on how Sami needs to treat them:
 


### PR DESCRIPTION
The php, twig and yaml examples are now properly highlighted.
