### PR TITLE
Look into interfaces parents when requesting parent method

### DIFF
--- a/Sami/Reflection/ClassReflection.php
+++ b/Sami/Reflection/ClassReflection.php
@@ -210,7 +210,7 @@ class ClassReflection extends Reflection
             }
         }
 
-        foreach ($this->getInterfaces() as $interface) {
+        foreach ($this->getInterfaces(true) as $interface) {
             foreach ($interface->getMethods() as $n => $method) {
                 if ($name == $n) {
                     return $method;


### PR DESCRIPTION
When looking for parent method, search is limited to immediate interfaces.

This PR fix the behavior and extend search to interfaces parents
