### PR TITLE
Fixed crash if no-ansi option is selected

### DIFF
--- a/Sami/Console/Command/Command.php
+++ b/Sami/Console/Command/Command.php
@@ -197,6 +197,10 @@ abstract class Command extends BaseCommand
 
     public function displayParseSummary()
     {
+        if ($this->input->getOption('no-ansi')) {
+            return;
+        }
+
         $this->output->writeln('');
         $this->output->writeln('<bg=cyan;fg=white> Version </>  <bg=cyan;fg=white> Updated C </>  <bg=cyan;fg=white> Removed C </>');
 
@@ -208,6 +212,10 @@ abstract class Command extends BaseCommand
 
     public function displayRenderSummary()
     {
+        if ($this->input->getOption('no-ansi')) {
+            return;
+        }
+
         $this->output->writeln('<bg=cyan;fg=white> Version </>  <bg=cyan;fg=white> Updated C </>  <bg=cyan;fg=white> Updated N </>  <bg=cyan;fg=white> Removed C </>  <bg=cyan;fg=white> Removed N </>');
 
         foreach ($this->diffs as $version => $diff) {


### PR DESCRIPTION
Not sure if it is the best way to fix that, but it works.

Detail on the issue : 

```
php vendor/bin/sami.php --no-ansi  update _sami/sami.php --force
 Updating project

 Version    Updated C    Removed C



  [ErrorException]
  Warning: Invalid argument supplied for foreach() in /home/lyrixx/dev/lifestream-doc/vendor/sami/sami/Sami/Console/Command/Command.php line 208



update [--force] config
```

BTW, the bug exists also with `--no-ansi --quiet`
