### PR TITLE
Added default for arrays to prevent errors in php 5.4+

### DIFF
--- a/Sami/Console/Command/Command.php
+++ b/Sami/Console/Command/Command.php
@@ -197,7 +197,10 @@ abstract class Command extends BaseCommand
 
     public function displayParseSummary()
     {
-        if (count($this->transactions) <= 0) return;
+        if (count($this->transactions) <= 0) {
+            return;
+        }
+        
         $this->output->writeln('');
         $this->output->writeln('<bg=cyan;fg=white> Version </>  <bg=cyan;fg=white> Updated C </>  <bg=cyan;fg=white> Removed C </>');
 
@@ -209,7 +212,10 @@ abstract class Command extends BaseCommand
 
     public function displayRenderSummary()
     {
-        if (count($this->diffs) <= 0) return;
+        if (count($this->diffs) <= 0) {
+            return;
+        }
+        
         $this->output->writeln('<bg=cyan;fg=white> Version </>  <bg=cyan;fg=white> Updated C </>  <bg=cyan;fg=white> Updated N </>  <bg=cyan;fg=white> Removed C </>  <bg=cyan;fg=white> Removed N </>');
 
         foreach ($this->diffs as $version => $diff) {


### PR DESCRIPTION
Initialized array properties with empty arrays in `Sami/Console/Command` so it doesn't break on php 5.4+.

Also added sanity checks in `displayParseSummary` and `displayRenderSummary` to prevent iterating over empty arrays (also causes an error).
