### PR TITLE
Clicking an item in the panel frame wasn't working when inside an <iframe>

### DIFF
--- a/Sami/Resources/themes/enhanced/panel.twig
+++ b/Sami/Resources/themes/enhanced/panel.twig
@@ -20,7 +20,7 @@
              dataType: 'script',
              success: function () {
                  $('.loader').css('display', 'none');
-                 var panel = new Searchdoc.Panel($('#panel'), search_data, tree, top.frames[1]);
+                 var panel = new Searchdoc.Panel($('#panel'), search_data, tree, parent.frames[1]);
                  $('#search').focus();
 
                  for (var i=0; i < {{ project.config('default_opened_level', 0) }}; i++) {


### PR DESCRIPTION
This little fix makes the panel work when inside an `<iframe>`.

This is useful, for example, when you're using Sami with Jenkins+[HTML Publisher Plugin](https://wiki.jenkins-ci.org/display/JENKINS/HTML+Publisher+Plugin) to build your docs, since the plugin uses an `<iframe>` to embed the webpage you specify.
