### PR TITLE
PR: fix bc break in PHP_Parser <0.9.2

### DIFF
--- a/Sami/Parser/CodeParser.php
+++ b/Sami/Parser/CodeParser.php
@@ -19,8 +19,8 @@ class CodeParser
 
     public function __construct(ParserContext $context, \PHPParser_Parser $parser, \PHPParser_NodeTraverser $traverser)
     {
-        $this->context = $context;
-        $this->parser = $parser;
+        $this->context   = $context;
+        $this->parser    = $parser;
         $this->traverser = $traverser;
     }
 
@@ -32,7 +32,11 @@ class CodeParser
     public function parse($code)
     {
         try {
-            $this->traverser->traverse($this->parser->parse($code));
+            try {
+                $this->traverser->traverse($this->parser->parse($code));
+            } catch (\ErrorException $e) {
+                $this->traverser->traverse($this->parser->parse(new \PHPParser_Lexer($code)));
+            }
         } catch (\PHPParser_Error $e) {
             $this->context->addError($this->context->getFile(), 0, $e->getMessage());
         }


### PR DESCRIPTION
When using other bundles like "JMS/TranslationBundle" who require php_parser = v0.9.1, Sami breaks.

They changed their api as you can see here: https://raw.github.com/nikic/PHP-Parser/master/CHANGELOG.md  changelog v0.9.2: [BC] Use inject-once approach for lexer.

I found no way to check for the package it's version so i wrapped it around a try catch. If anyone has a better solution feel free to add.
