### PR TITLE
Clarified error message when count of @param tags != count method params

### DIFF
--- a/Sami/Parser/NodeVisitor.php
+++ b/Sami/Parser/NodeVisitor.php
@@ -94,7 +94,6 @@ class NodeVisitor extends \PHPParser_NodeVisitorAbstract
         $class->setTrait(true);
     }
 
-
     protected function addClassOrInterface($node)
     {
         $class = new ClassReflection((string) $node->namespacedName, $node->getLine());


### PR DESCRIPTION
Hi, the old message for the case where the number of @param tags was not equal to the number of parameters that a method actually has was not especially clear. Hopefully this version is slightly easier to understand!
