### PR TITLE
Project title is missing in generated documentation

### DIFF
--- a/Sami/Sami.php
+++ b/Sami/Sami.php
@@ -62,6 +62,7 @@ class Sami extends \Pimple
                 'include_parent_data' => $sc['include_parent_data'],
                 'default_opened_level' => $sc['default_opened_level'],
                 'theme' => $sc['theme'],
+                'title' => $sc['title'],
             ));
             $project->setRenderer($sc['renderer']);
             $project->setParser($sc['parser']);


### PR DESCRIPTION
Specified project title isn't included in generated documentation.

Before:
![sami_withoutshowntitle](https://cloud.githubusercontent.com/assets/1277526/3382292/b6c20cbc-fc36-11e3-8060-6fdb8d4b875c.png)

After:
![sami_withshowntitle](https://cloud.githubusercontent.com/assets/1277526/3382293/bb31ef9c-fc36-11e3-9188-ceece5b90dab.png)
