### PR TITLE
Show "From ..." class for properties (when defined in super class)

### DIFF
--- a/Sami/Resources/themes/default/pages/class.twig
+++ b/Sami/Resources/themes/default/pages/class.twig
@@ -1,6 +1,6 @@
 {% extends page_layout %}
 
-{% from "macros.twig" import namespace_link, class_link, method_link, hint_link %}
+{% from "macros.twig" import namespace_link, class_link, property_link, method_link, hint_link %}
 
 {% block title %}{{ class.name }} | {{ parent() }}{% endblock %}
 
@@ -144,6 +144,11 @@
                 </td>
                 <td>${{ property.name }}</td>
                 <td class="last">{{ property.shortdesc|desc(class) }}</td>
+                <td>
+                    {%- if property.class is not sameas(class) -%}
+                        <small>from&nbsp;{{ property_link(property, {}, false, true) }}</small>
+                    {%- endif -%}
+                </td>
             </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
I like how class, where method is originally defined is listed on the right of method name. Here I'm just replicating this for class properties:
![sami_fromforproperties](https://cloud.githubusercontent.com/assets/1277526/3388728/d6b6e4ac-fc8b-11e3-8692-2d8cfe658566.png)
