### PR TITLE
Adding "View Source" link to the class page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,7 @@ that matter any instance of the Symfony `Finder`_ class):
     <?php
 
     use Sami\Sami;
+    use Sami\RemoteRepository\GitHubRemoteRepository;
     use Symfony\Component\Finder\Finder;
 
     $iterator = Finder::create()
@@ -65,6 +66,7 @@ argument:
         'title'                => 'Symfony2 API',
         'build_dir'            => __DIR__.'/build',
         'cache_dir'            => __DIR__.'/cache',
+        'remote_repository'    => new GitHubRemoteRepository('username/repository', '/path/to/repository'),
         'default_opened_level' => 2,
     ));
 
@@ -75,6 +77,7 @@ And here is how you can configure different versions:
     <?php
 
     use Sami\Sami;
+    use Sami\RemoteRepository\GitHubRemoteRepository;
     use Sami\Version\GitVersionCollection;
     use Symfony\Component\Finder\Finder;
 
@@ -99,6 +102,7 @@ And here is how you can configure different versions:
         'title'                => 'Symfony2 API',
         'build_dir'            => __DIR__.'/../build/sf2/%version%',
         'cache_dir'            => __DIR__.'/../cache/sf2/%version%',
+        'remote_repository'    => new GitHubRemoteRepository('symfony/symfony', dirname($dir)),
         'default_opened_level' => 2,
     ));
 

--- a/Sami/Parser/ClassVisitor/ViewSourceClassVisitor.php
+++ b/Sami/Parser/ClassVisitor/ViewSourceClassVisitor.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sami utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sami\Parser\ClassVisitor;
+
+use Sami\Reflection\ClassReflection;
+use Sami\Parser\ClassVisitorInterface;
+use Sami\RemoteRepository\AbstractRemoteRepository;
+
+class ViewSourceClassVisitor implements ClassVisitorInterface
+{
+    /** @var AbstractRemoteRepository */
+    protected $remoteRepository;
+
+    public function __construct(AbstractRemoteRepository $remoteRepository)
+    {
+        $this->remoteRepository = $remoteRepository;
+    }
+
+    public function visit(ClassReflection $class)
+    {
+        $filePath = $this->remoteRepository->getRelativePath($class->getFile());
+
+        if ('' !== $filePath) {
+            $class->setRelativeFilePath($filePath);
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Sami/Parser/Parser.php
+++ b/Sami/Parser/Parser.php
@@ -23,15 +23,13 @@ class Parser
     protected $iterator;
     protected $parser;
     protected $traverser;
-    protected $sourceDir;
 
-    public function __construct($iterator, StoreInterface $store, CodeParser $parser, ClassTraverser $traverser, $sourceDir)
+    public function __construct($iterator, StoreInterface $store, CodeParser $parser, ClassTraverser $traverser)
     {
         $this->iterator = $this->createIterator($iterator);
         $this->store = $store;
         $this->parser = $parser;
         $this->traverser = $traverser;
-        $this->sourceDir = (array) $sourceDir;
     }
 
     public function parse(Project $project, $callback = null)
@@ -60,13 +58,6 @@ class Parser
             foreach ($context->leaveFile() as $class) {
                 if (null !== $callback) {
                     call_user_func($callback, Message::PARSE_CLASS, array(floor($step / $steps * 100), $class));
-                }
-
-                foreach ($this->sourceDir as $dir) {
-                    if ($file !== ($plainFile = str_replace($dir, '', $file))) {
-                        $class->setPlainFile($plainFile);
-                        break;
-                    }
                 }
 
                 $project->addClass($class);

--- a/Sami/Parser/Parser.php
+++ b/Sami/Parser/Parser.php
@@ -23,13 +23,15 @@ class Parser
     protected $iterator;
     protected $parser;
     protected $traverser;
+    protected $sourceDir;
 
-    public function __construct($iterator, StoreInterface $store, CodeParser $parser, ClassTraverser $traverser)
+    public function __construct($iterator, StoreInterface $store, CodeParser $parser, ClassTraverser $traverser, $sourceDir)
     {
         $this->iterator = $this->createIterator($iterator);
         $this->store = $store;
         $this->parser = $parser;
         $this->traverser = $traverser;
+        $this->sourceDir = (array) $sourceDir;
     }
 
     public function parse(Project $project, $callback = null)
@@ -58,6 +60,13 @@ class Parser
             foreach ($context->leaveFile() as $class) {
                 if (null !== $callback) {
                     call_user_func($callback, Message::PARSE_CLASS, array(floor($step / $steps * 100), $class));
+                }
+
+                foreach ($this->sourceDir as $dir) {
+                    if ($file !== ($plainFile = str_replace($dir, '', $file))) {
+                        $class->setPlainFile($plainFile);
+                        break;
+                    }
                 }
 
                 $project->addClass($class);

--- a/Sami/Project.php
+++ b/Sami/Project.php
@@ -15,6 +15,7 @@ use Sami\Parser\Parser;
 use Sami\Reflection\ClassReflection;
 use Sami\Reflection\LazyClassReflection;
 use Sami\Renderer\Renderer;
+use Sami\RemoteRepository\AbstractRemoteRepository;
 use Sami\Store\StoreInterface;
 use Sami\Version\SingleVersionCollection;
 use Sami\Version\Version;
@@ -30,9 +31,16 @@ class Project
 {
     protected $versions;
     protected $store;
+
+    /** @var Parser */
     protected $parser;
+
+    /** @var Renderer */
     protected $renderer;
+
+    /** @var ClassReflection[] */
     protected $classes;
+
     protected $namespaceClasses;
     protected $namespaceInterfaces;
     protected $namespaceExceptions;
@@ -482,7 +490,18 @@ class Project
         }
 
         if (strpos($root, 'github') !== false) {
-            return $root . '/tree/' . $this->version;
+            return $root.'/tree/'.$this->version;
         }
+    }
+
+    public function getViewSourceUrl($relativePath, $line)
+    {
+        $remoteRepository = $this->getConfig('remote_repository');
+
+        if ($remoteRepository instanceof AbstractRemoteRepository) {
+            return $remoteRepository->getFileUrl($this->version, $relativePath, $line);
+        }
+
+        return '';
     }
 }

--- a/Sami/Project.php
+++ b/Sami/Project.php
@@ -474,4 +474,15 @@ class Project
             call_user_func($callback, Message::RENDER_VERSION_FINISHED, $diff);
         }
     }
+
+    public function getSourceRoot()
+    {
+        if (!$root = $this->getConfig('source_url')) {
+            return;
+        }
+
+        if (strpos($root, 'github') !== false) {
+            return $root . '/tree/' . $this->version;
+        }
+    }
 }

--- a/Sami/Reflection/ClassReflection.php
+++ b/Sami/Reflection/ClassReflection.php
@@ -25,7 +25,9 @@ class ClassReflection extends Reflection
         3 => 'trait',
     );
 
+    /** @var Project */
     protected $project;
+
     protected $hash;
     protected $namespace;
     protected $modifiers;
@@ -36,7 +38,7 @@ class ClassReflection extends Reflection
     protected $traits = array();
     protected $parent;
     protected $file;
-    protected $plainFile;
+    protected $relativeFilePath;
     protected $category = self::CATEGORY_CLASS;
     protected $projectClass = true;
     protected $aliases = array();
@@ -112,37 +114,23 @@ class ClassReflection extends Reflection
         $this->file = $file;
     }
 
-    public function setPlainFile($plainFile)
+    public function setRelativeFilePath($relativeFilePath)
     {
-        $this->plainFile = $plainFile;
+        $this->relativeFilePath = $relativeFilePath;
     }
 
-    public function getPlainFile()
+    public function getRelativeFilePath()
     {
-        return $this->plainFile;
+        return $this->relativeFilePath;
     }
 
     public function getSourcePath($line = null)
     {
-        if (null === $this->project) {
-            return;
+        if (null === $this->relativeFilePath) {
+            return '';
         }
 
-        if (!$root = $this->project->getSourceRoot()) {
-            return;
-        }
-
-        if (null === $this->plainFile) {
-            return;
-        }
-
-        $url = $root . $this->plainFile;
-
-        if (null !== $line) {
-            $url .= '#L' . (int) $line;
-        }
-
-        return $url;
+        return $this->project->getViewSourceUrl($this->relativeFilePath, $line);
     }
 
     public function getProject()
@@ -467,8 +455,7 @@ class ClassReflection extends Reflection
             'tags'         => $this->tags,
             'namespace'    => $this->namespace,
             'file'         => $this->file,
-            'plain_file'   => $this->getPlainFile(),
-            'source_path'  => $this->getSourcePath(),
+            'relative_file'=> $this->relativeFilePath,
             'hash'         => $this->hash,
             'parent'       => $this->parent,
             'modifiers'    => $this->modifiers,
@@ -487,15 +474,15 @@ class ClassReflection extends Reflection
     public static function fromArray(Project $project, $array)
     {
         $class = new self($array['name'], $array['line']);
-        $class->shortDesc  = $array['short_desc'];
-        $class->longDesc   = $array['long_desc'];
-        $class->hint       = $array['hint'];
-        $class->tags       = $array['tags'];
-        $class->namespace  = $array['namespace'];
-        $class->hash       = $array['hash'];
-        $class->file       = $array['file'];
-        $class->plainFile  = $array['plain_file'];
-        $class->modifiers  = $array['modifiers'];
+        $class->shortDesc        = $array['short_desc'];
+        $class->longDesc         = $array['long_desc'];
+        $class->hint             = $array['hint'];
+        $class->tags             = $array['tags'];
+        $class->namespace        = $array['namespace'];
+        $class->hash             = $array['hash'];
+        $class->file             = $array['file'];
+        $class->relativeFilePath = $array['relative_file'];
+        $class->modifiers        = $array['modifiers'];
         if ($array['is_interface']) {
             $class->setInterface(true);
         }

--- a/Sami/Reflection/ClassReflection.php
+++ b/Sami/Reflection/ClassReflection.php
@@ -36,6 +36,7 @@ class ClassReflection extends Reflection
     protected $traits = array();
     protected $parent;
     protected $file;
+    protected $plainFile;
     protected $category = self::CATEGORY_CLASS;
     protected $projectClass = true;
     protected $aliases = array();
@@ -109,6 +110,39 @@ class ClassReflection extends Reflection
     public function setFile($file)
     {
         $this->file = $file;
+    }
+
+    public function setPlainFile($plainFile)
+    {
+        $this->plainFile = $plainFile;
+    }
+
+    public function getPlainFile()
+    {
+        return $this->plainFile;
+    }
+
+    public function getSourcePath($line = null)
+    {
+        if (null === $this->project) {
+            return;
+        }
+
+        if (!$root = $this->project->getSourceRoot()) {
+            return;
+        }
+
+        if (null === $this->plainFile) {
+            return;
+        }
+
+        $url = $root . $this->plainFile;
+
+        if (null !== $line) {
+            $url .= '#L' . (int) $line;
+        }
+
+        return $url;
     }
 
     public function getProject()
@@ -433,6 +467,8 @@ class ClassReflection extends Reflection
             'tags'         => $this->tags,
             'namespace'    => $this->namespace,
             'file'         => $this->file,
+            'plain_file'   => $this->getPlainFile(),
+            'source_path'  => $this->getSourcePath(),
             'hash'         => $this->hash,
             'parent'       => $this->parent,
             'modifiers'    => $this->modifiers,
@@ -458,6 +494,7 @@ class ClassReflection extends Reflection
         $class->namespace  = $array['namespace'];
         $class->hash       = $array['hash'];
         $class->file       = $array['file'];
+        $class->plainFile  = $array['plain_file'];
         $class->modifiers  = $array['modifiers'];
         if ($array['is_interface']) {
             $class->setInterface(true);

--- a/Sami/RemoteRepository/AbstractRemoteRepository.php
+++ b/Sami/RemoteRepository/AbstractRemoteRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sami utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sami\RemoteRepository;
+
+abstract class AbstractRemoteRepository
+{
+    protected $name;
+    protected $localPath;
+
+    public function __construct($name, $localPath)
+    {
+        $this->name = $name;
+        $this->localPath = $localPath;
+    }
+
+    abstract public function getFileUrl($projectVersion, $relativePath, $line);
+
+    public function getRelativePath($file)
+    {
+        $replacementCount = 0;
+        $filePath = str_replace($this->localPath, '', $file, $replacementCount);
+
+        if (1 === $replacementCount) {
+            return $filePath;
+        }
+
+        return '';
+    }
+}

--- a/Sami/RemoteRepository/GitHubRemoteRepository.php
+++ b/Sami/RemoteRepository/GitHubRemoteRepository.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Sami utility.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sami\RemoteRepository;
+
+class GitHubRemoteRepository extends AbstractRemoteRepository
+{
+    public function getFileUrl($projectVersion, $relativePath, $line)
+    {
+        $url = 'https://github.com/'.$this->name.'/blob/'.$projectVersion.$relativePath;
+
+        if (null !== $line) {
+            $url .= '#L'.(int) $line;
+        }
+
+        return $url;
+    }
+}

--- a/Sami/Resources/themes/default/class.twig
+++ b/Sami/Resources/themes/default/class.twig
@@ -1,5 +1,5 @@
 {% extends "layout/layout.twig" %}
-{% from "macros.twig" import render_classes, breadcrumbs, namespace_link, class_link, property_link, method_link, hint_link %}
+{% from "macros.twig" import render_classes, breadcrumbs, namespace_link, class_link, property_link, method_link, hint_link, source_link %}
 {% block title %}{{ class.name }} | {{ parent() }}{% endblock %}
 {% block body_class 'class' %}
 {% block page_id 'class:' ~ (class.name|replace({'\\': '_'})) %}
@@ -79,6 +79,7 @@
             {%- if not loop.last %}, {% endif %}
         {%- endfor %}
     {%- endif %}
+    {{- source_link(project, class) }}
 {% endblock %}
 
 {% block method_signature -%}

--- a/Sami/Resources/themes/default/macros.twig
+++ b/Sami/Resources/themes/default/macros.twig
@@ -38,6 +38,12 @@
     {%- endif %}
 {%- endmacro %}
 
+{% macro source_link(project, class) -%}
+    {% if class.sourcepath %}
+        <a href="{{ class.sourcepath }}">View source</a>
+    {%- endif %}
+{%- endmacro %}
+
 {% macro abbr_class(class, absolute) -%}
     <abbr title="{{ class }}">{{ absolute|default(false) ? class : class.shortname }}</abbr>
 {%- endmacro %}

--- a/Sami/Resources/themes/default/macros.twig
+++ b/Sami/Resources/themes/default/macros.twig
@@ -40,7 +40,7 @@
 
 {% macro source_link(project, class) -%}
     {% if class.sourcepath %}
-        <a href="{{ class.sourcepath }}">View source</a>
+        (<a href="{{ class.sourcepath }}">View source</a>)
     {%- endif %}
 {%- endmacro %}
 

--- a/Sami/Sami.php
+++ b/Sami/Sami.php
@@ -25,6 +25,7 @@ use Sami\Parser\Filter\DefaultFilter;
 use Sami\Parser\NodeVisitor;
 use Sami\Parser\Parser;
 use Sami\Parser\ParserContext;
+use Sami\RemoteRepository\AbstractRemoteRepository;
 use Sami\Renderer\Renderer;
 use Sami\Renderer\ThemeSet;
 use Sami\Renderer\TwigExtension;
@@ -64,6 +65,7 @@ class Sami extends Container
             $project = new Project($sc['store'], $sc['_versions'], array(
                 'build_dir' => $sc['build_dir'],
                 'cache_dir' => $sc['cache_dir'],
+                'remote_repository' => $sc['remote_repository'],
                 'simulate_namespaces' => $sc['simulate_namespaces'],
                 'include_parent_data' => $sc['include_parent_data'],
                 'default_opened_level' => $sc['default_opened_level'],
@@ -130,12 +132,16 @@ class Sami extends Container
             return new Renderer($sc['twig'], $sc['themes'], $sc['tree'], $sc['indexer']);
         };
 
-        $this['traverser'] = function () {
+        $this['traverser'] = function ($sc) {
             $visitors = array(
                 new ClassVisitor\InheritdocClassVisitor(),
                 new ClassVisitor\MethodClassVisitor(),
                 new ClassVisitor\PropertyClassVisitor(),
             );
+
+            if ($sc['remote_repository'] instanceof AbstractRemoteRepository) {
+                $visitors[] = new ClassVisitor\ViewSourceClassVisitor($sc['remote_repository']);
+            }
 
             return new ClassTraverser($visitors);
         };
@@ -165,6 +171,7 @@ class Sami extends Container
         $this['template_dirs'] = array();
         $this['build_dir'] = getcwd().'/build';
         $this['cache_dir'] = getcwd().'/cache';
+        $this['remote_repository'] = null;
         $this['source_dir'] = '';
         $this['source_url'] = '';
         $this['default_opened_level'] = 2;

--- a/Sami/Sami.php
+++ b/Sami/Sami.php
@@ -69,6 +69,8 @@ class Sami extends Container
                 'default_opened_level' => $sc['default_opened_level'],
                 'theme' => $sc['theme'],
                 'title' => $sc['title'],
+                'source_url' => $sc['source_url'],
+                'source_dir' => $sc['source_dir'],
             ));
             $project->setRenderer($sc['renderer']);
             $project->setParser($sc['parser']);
@@ -163,6 +165,8 @@ class Sami extends Container
         $this['template_dirs'] = array();
         $this['build_dir'] = getcwd().'/build';
         $this['cache_dir'] = getcwd().'/cache';
+        $this['source_dir'] = '';
+        $this['source_url'] = '';
         $this['default_opened_level'] = 2;
 
         // simulate namespaces for projects based on the PEAR naming conventions


### PR DESCRIPTION
This is an implementation of #63 task based on original commit made in #64.

___Usage___
By default Sami doesn't know on which hosting Git repository is located and doesn't add `View Source` links on class detail pages. However if you specify `remote_repository` option with instance of `AbstractRemoteRepository` class sub-class, then the `View Source` link would be added:

![sami_viewsourcelink](https://cloud.githubusercontent.com/assets/1277526/3411930/ed431ede-fdf8-11e3-89df-0d6019d5f51c.png)

For example:

```php
array(
...
'remote_repository' => new GitHubRemoteRepository('username/repository', '/path/to/repository'),
...
)
```
The `'/path/to/repository'` is required, because Sami doesn't know base folder on GitHub (or any other service), where original files (for which documentation is being generated) live.

Thanks to @anlutro, which commit (squashed) was used as a base for my changes.

Closes #63