### PR TITLE
Fixing TrueFilter example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,11 @@ You can find more configuration examples under the ``examples/`` directory of
 the source code.
 
 Sami only documents the public API (public properties and methods); override
-the default configured ``filter`` to change this behavior::
+the default configured ``filter`` to change this behavior:
+
+.. code-block:: php
+
+    <?php
 
     use Sami\Parser\Filter\TrueFilter;
 


### PR DESCRIPTION
In the config file $this doesn't represent Sami instance and will lead to Fatal Error.

The syntax highlighting was also fixed in the example code.
