### PR TITLE
Preserve new line symbols in short description

### DIFF
--- a/Sami/Parser/DocBlockParser.php
+++ b/Sami/Parser/DocBlockParser.php
@@ -62,6 +62,9 @@ class DocBlockParser
 
     protected function parseDesc()
     {
+        $short = '';
+        $long = '';
+
         if (preg_match('/(.*?)(\n[ \t]*'.self::TAG_REGEX.'|$)/As', $this->comment, $match, null, $this->cursor)) {
             $this->move($match[1]);
 
@@ -81,7 +84,9 @@ class DocBlockParser
 
         $this->position = 'tag';
 
-        return array(str_replace("\n", '', $short), $long);
+        $shortParts = array_map('trim', explode("\n", $short));
+
+        return array(implode("\n", $shortParts), $long);
     }
 
     protected function parseTag()

--- a/Sami/Tests/Parser/DocBlockParserTest.php
+++ b/Sami/Tests/Parser/DocBlockParserTest.php
@@ -51,7 +51,7 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
                  * lines.
                  */
                 ',
-                array('shortdesc' => 'The short desc on two lines.'),
+                array('shortdesc' => "The short desc on two\nlines."),
             ),
             array('
                 /**
@@ -73,7 +73,7 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
                  * With another paragraph.
                  */
                 ',
-                array('shortdesc' => 'The short desc on two lines.', 'longdesc' => "And a long desc on\nseveral lines too.\n\nWith another paragraph."),
+                array('shortdesc' => "The short desc on two\nlines.", 'longdesc' => "And a long desc on\nseveral lines too.\n\nWith another paragraph."),
             ),
             array('
                 /**


### PR DESCRIPTION
Preserve new line symbols in short description, but remove any leading whitespaces from each line.

This change one of the change set to bring used DocBlock parser in sync with https://github.com/phpDocumentor/ReflectionDocBlock .

Closes to #102
