### PR TITLE
New line symbol after dot is required to separate short and long description

### DIFF
--- a/Sami/Parser/DocBlockParser.php
+++ b/Sami/Parser/DocBlockParser.php
@@ -68,8 +68,8 @@ class DocBlockParser
             $short = trim($match[1]);
             $long = '';
 
-            // short desc ends at the first dot or when \n\n occurs
-            if (preg_match('/(.*?)(\.\s|\n\n|$)/s', $short, $match)) {
+            // short desc ends at the first dot with \n after it or when \n\n occurs
+            if (preg_match('/(.*?)(\.\n|\n\n|$)/s', $short, $match)) {
                 $long = trim(substr($short, strlen($match[0])));
                 $short = trim($match[0]);
             }

--- a/Sami/Tests/Parser/DocBlockParserTest.php
+++ b/Sami/Tests/Parser/DocBlockParserTest.php
@@ -77,10 +77,10 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
             ),
             array('
                 /**
-                 * The short desc with a @tag embedded. And the long desc with a @tag embedded too.
+                 * The short desc with a @tag embedded. And the short desc continues after dot on same line.
                  */
                 ',
-                array('shortdesc' => 'The short desc with a @tag embedded.', 'longdesc' => 'And the long desc with a @tag embedded too.'),
+                array('shortdesc' => 'The short desc with a @tag embedded. And the short desc continues after dot on same line.'),
             ),
             array('
                 /**


### PR DESCRIPTION
Change short description detection logic to match one used in current PhpDocumentor version (v2). Now short description can be separated from long description by these means:
- dot and \n
- \n\n

before it was
- dot
- \n\n

Closes #104
