### PR TITLE
Make DocBlock parser use PhpDocumentor's DocBlock component

### DIFF
--- a/Sami/Parser/DocBlockParser.php
+++ b/Sami/Parser/DocBlockParser.php
@@ -11,127 +11,79 @@
 
 namespace Sami\Parser;
 
+use phpDocumentor\Reflection\DocBlock;
 use Sami\Parser\Node\DocBlockNode;
 
 class DocBlockParser
 {
-    const TAG_REGEX = '@([^ ]+)(?:\s+(.*?))?(?=(\n[ \t]*@|\s*$))';
-
-    protected $position;
-    protected $comment;
-    protected $lineno;
-    protected $cursor;
-
-    public function parse($comment)
+    public function parse($comment, ParserContext $context)
     {
-        // remove comment characters and normalize
-        $comment = preg_replace(array('#^/\*\*\s*#', '#\s*\*/$#', '#^\s*\*#m'), '', trim($comment));
-        $comment = "\n".preg_replace('/(\r\n|\r)/', "\n", $comment);
+        $docBlock = null;
+        $errorMessage = '';
 
-        $this->position = 'desc';
-        $this->comment = $comment;
-        $this->lineno = 1;
-        $this->cursor = 0;
-
-        $doc = new DocBlockNode();
-        while ($this->cursor < strlen($this->comment)) {
-            switch ($this->position) {
-                case 'desc':
-                    list($short, $long) = $this->parseDesc();
-                    $doc->setShortDesc($short);
-                    $doc->setLongDesc($long);
-                    break;
-
-                case 'tag':
-                    try {
-                        list($type, $values) = $this->parseTag();
-                        $doc->addTag($type, $values);
-                    } catch (\LogicException $e) {
-                        $doc->addError($e->getMessage());
-                    }
-                    break;
-            }
-
-            if (preg_match('/\s*$/As', $this->comment, $match, null, $this->cursor)) {
-                $this->cursor = strlen($this->comment);
-            }
+        try {
+            $docBlockContext = new DocBlock\Context($context->getNamespace(), $context->getAliases());
+            $docBlock = new DocBlock((string) $comment, $docBlockContext);
+        } catch (\Exception $e) {
+            $errorMessage = $e->getMessage();
         }
 
-        return $doc;
-    }
+        $result = new DocBlockNode();
 
-    protected function parseDesc()
-    {
-        $short = '';
-        $long = '';
+        if ($errorMessage) {
+            $result->addError($errorMessage);
 
-        if (preg_match('/(.*?)(\n[ \t]*'.self::TAG_REGEX.'|$)/As', $this->comment, $match, null, $this->cursor)) {
-            $this->move($match[1]);
-
-            $short = trim($match[1]);
-            $long = '';
-
-            // short desc ends at the first dot with \n after it or when \n\n occurs
-            if (preg_match('/(.*?)(\.\n|\n\n|$)/s', $short, $match)) {
-                $long = trim(substr($short, strlen($match[0])));
-                $short = trim($match[0]);
-            }
-
-            // remove single lead space
-            $short = preg_replace('/^ /', '', $short);
-            $long = preg_replace('/^ /m', '', $long);
+            return $result;
         }
 
-        $this->position = 'tag';
+        $result->setShortDesc($docBlock->getShortDescription());
+        $result->setLongDesc((string) $docBlock->getLongDescription());
 
-        $shortParts = array_map('trim', explode("\n", $short));
-
-        return array(implode("\n", $shortParts), $long);
-    }
-
-    protected function parseTag()
-    {
-        if (preg_match('/\n\s*'.self::TAG_REGEX.'/As', $this->comment, $match, null, $this->cursor)) {
-            $this->move($match[0]);
-
-            switch ($type = $match[1]) {
-                case 'param':
-                    if (!preg_match('/^([^\s]*)\s*(?:(?:\$|\&\$)([^\s]+))?\s*(.*)$/s', $match[2], $m)) {
-                        throw new \LogicException(sprintf('Unable to parse "@%s" tag " %s"', $type, $match[2]));
-                    }
-
-                    return array($type, array($this->parseHint(trim($m[1])), trim($m[2]), $this->normalizeString($m[3])));
-
-                case 'return':
-                case 'var':
-                    if (!preg_match('/^([^\s]+)\s*(.*)$/s', $match[2], $m)) {
-                        throw new \LogicException(sprintf('Unable to parse "@%s" tag "%s"', $type, $match[2]));
-                    }
-
-                    return array($type, array($this->parseHint(trim($m[1])), $this->normalizeString($m[2])));
-
-                case 'throws':
-                    if (!preg_match('/^([^\s]+)\s*(.*)$/s', $match[2], $m)) {
-                        throw new \LogicException(sprintf('Unable to parse "@%s" tag "%s"', $type, $match[2]));
-                    }
-
-                    return array($type, array(trim($m[1]), $this->normalizeString($m[2])));
-
-                default:
-                    return array($type, $this->normalizeString($match[2]));
-            }
-        } else {
-            // skip
-            $this->cursor = strlen($this->comment);
-
-            throw new \LogicException(sprintf('Unable to parse block comment near "... %s ...".', substr($this->comment, max(0, $this->cursor - 15), 15)));
+        foreach ($docBlock->getTags() as $tag) {
+            $result->addTag($tag->getName(), $this->parseTag($tag));
         }
+
+        return $result;
     }
 
-    protected function parseHint($hint)
+    protected function parseTag(DocBlock\Tag $tag)
+    {
+        if ($tag instanceof DocBlock\Tag\VarTag) {
+            return array(
+                $this->parseHint($tag->getTypes()),
+                $tag->getDescription(),
+            );
+        }
+
+        if ($tag instanceof DocBlock\Tag\ParamTag) {
+            return array(
+                $this->parseHint($tag->getTypes()),
+                ltrim($tag->getVariableName(), '$'),
+                $tag->getDescription(),
+            );
+        }
+
+        if ($tag instanceof DocBlock\Tag\ThrowsTag) {
+            return array(
+                $tag->getType(),
+                $tag->getDescription(),
+            );
+        }
+
+        if ($tag instanceof DocBlock\Tag\ReturnTag) {
+            return array(
+                $this->parseHint($tag->getTypes()),
+                $tag->getDescription(),
+            );
+        }
+
+        return $tag->getContent();
+    }
+
+    protected function parseHint($rawHints)
     {
         $hints = array();
-        foreach (explode('|', $hint) as $hint) {
+        foreach ($rawHints as $hint) {
             if ('[]' == substr($hint, -2)) {
                 $hints[] = array(substr($hint, 0, -2), true);
             } else {
@@ -140,16 +92,5 @@ class DocBlockParser
         }
 
         return $hints;
-    }
-
-    protected function normalizeString($str)
-    {
-        return preg_replace('/\s*\n\s*/', ' ', trim($str));
-    }
-
-    protected function move($text)
-    {
-        $this->lineno += substr_count($text, "\n");
-        $this->cursor += strlen($text);
     }
 }

--- a/Sami/Parser/NodeVisitor.php
+++ b/Sami/Parser/NodeVisitor.php
@@ -96,7 +96,7 @@ class NodeVisitor extends \PHPParser_NodeVisitorAbstract
         $class->setTrait(true);
     }
 
-    protected function addClassOrInterface($node)
+    protected function addClassOrInterface(\PHPParser_Node_Stmt $node)
     {
         $class = new ClassReflection((string) $node->namespacedName, $node->getLine());
         $class->setModifiers($node->type);

--- a/Sami/Parser/ParserContext.php
+++ b/Sami/Parser/ParserContext.php
@@ -13,7 +13,6 @@ namespace Sami\Parser;
 
 use Sami\Reflection\ClassReflection;
 use Sami\Parser\Filter\FilterInterface;
-use Sami\Parser\DocBlockParser;
 
 class ParserContext
 {

--- a/Sami/Tests/Parser/DocBlockParserTest.php
+++ b/Sami/Tests/Parser/DocBlockParserTest.php
@@ -23,7 +23,7 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
     {
         $parser = new DocBlockParser();
 
-        $this->assertEquals($this->createDocblock($expected), $parser->parse($comment));
+        $this->assertEquals($this->createDocblock($expected), $parser->parse($comment, $this->getContextMock()));
     }
 
     public function getParseTests()
@@ -129,5 +129,14 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
         }
 
         return $docblock;
+    }
+
+    private function getContextMock()
+    {
+        $contextMock = $this->getMockBuilder('Sami\Parser\ParserContext')->disableOriginalConstructor()->getMock();
+        $contextMock->expects($this->once())->method('getNamespace')->will($this->returnValue(''));
+        $contextMock->expects($this->once())->method('getAliases')->will($this->returnValue(array()));
+
+        return $contextMock;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "symfony/finder": "~2.1",
         "symfony/filesystem": "~2.1",
         "symfony/yaml": "~2.1",
-        "symfony/process": "~2.1"
+        "symfony/process": "~2.1",
+        "phpdocumentor/reflection-docblock": "~2.0"
     },
     "autoload": {
         "psr-0": { "Sami": "." }


### PR DESCRIPTION
Use DocBlock parser from phpDocumentor to ensure we always parse according to latest PhpDoc standards. All previous DocBlock parser tests are passing on phpDocumentor DocBlock parser as well.

Side benefit:
New DocBlock parser is converting class/interface/trait names to FQCN format and that allows to detect exception classes in `@throw` and `@throws` tags and make them clickable in generated documentation.

Parsing performance change: does it 1 second faster (was 34 seconds for me) on Symfony codebase.

Closes #101
