### PR TITLE
Add tests to verify proper parsing of each supported DocBlock tag

### DIFF
--- a/Sami/Parser/DocBlockParser.php
+++ b/Sami/Parser/DocBlockParser.php
@@ -48,14 +48,20 @@ class DocBlockParser
 
     protected function parseTag(DocBlock\Tag $tag)
     {
-        if ($tag instanceof DocBlock\Tag\VarTag) {
+        $tagClass = get_class($tag);
+
+        if ('phpDocumentor\Reflection\DocBlock\Tag\VarTag' === $tagClass) {
+            /** @var DocBlock\Tag\VarTag $tag */
+
             return array(
                 $this->parseHint($tag->getTypes()),
                 $tag->getDescription(),
             );
         }
 
-        if ($tag instanceof DocBlock\Tag\ParamTag) {
+        if ('phpDocumentor\Reflection\DocBlock\Tag\ParamTag' === $tagClass) {
+            /** @var DocBlock\Tag\ParamTag $tag */
+
             return array(
                 $this->parseHint($tag->getTypes()),
                 ltrim($tag->getVariableName(), '$'),
@@ -63,14 +69,18 @@ class DocBlockParser
             );
         }
 
-        if ($tag instanceof DocBlock\Tag\ThrowsTag) {
+        if ('phpDocumentor\Reflection\DocBlock\Tag\ThrowsTag' === $tagClass) {
+            /** @var DocBlock\Tag\ThrowsTag $tag */
+
             return array(
                 $tag->getType(),
                 $tag->getDescription(),
             );
         }
 
-        if ($tag instanceof DocBlock\Tag\ReturnTag) {
+        if ('phpDocumentor\Reflection\DocBlock\Tag\ReturnTag' === $tagClass) {
+            /** @var DocBlock\Tag\ReturnTag $tag */
+
             return array(
                 $this->parseHint($tag->getTypes()),
                 $tag->getDescription(),

--- a/Sami/Tests/Parser/DocBlockParserTest.php
+++ b/Sami/Tests/Parser/DocBlockParserTest.php
@@ -104,6 +104,117 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
                 ',
                 array('tags' => array('author' => array('Fabien <fabien@example.com>', 'Thomas <thomas@example.com>'))),
             ),
+            array('
+                /**
+                 * @var SingleClass|\MultipleClass[] Property Description
+                 */
+                ',
+                array(
+                    'tags' => array(
+                        'var' => array( // Array from found tags.
+                            array( // First found tag.
+                                array(array('\SingleClass', false), array('\MultipleClass', true)), // Array from data types.
+                                'Property Description',
+                            )
+                        )
+                    )
+                ),
+            ),
+            array('
+                /**
+                 * @param SingleClass|\MultipleClass[] $paramName Param Description
+                 */
+                ',
+                array(
+                    'tags' => array(
+                        'param' => array( // Array from found tags.
+                            array( // First found tag.
+                                array(array('\SingleClass', false), array('\MultipleClass', true)), // Array from data types.
+                                'paramName',
+                                'Param Description',
+                            )
+                        )
+                    )
+                ),
+            ),
+            array('
+                /**
+                 * @throw SingleClass1 Exception Description One
+                 * @throws SingleClass2 Exception Description Two
+                 */
+                ',
+                array(
+                    'tags' => array(
+                        'throw' => array( // Array from found tags.
+                            array( // First found tag.
+                                '\SingleClass1',
+                                'Exception Description One',
+                            )
+                        ),
+                        'throws' => array( // Array from found tags.
+                            array( // Second found tag.
+                                '\SingleClass2',
+                                'Exception Description Two',
+                            )
+                        ),
+                    )
+                ),
+            ),
+            array('
+                /**
+                 * @return SingleClass|\MultipleClass[] Return Description
+                 */
+                ',
+                array(
+                    'tags' => array(
+                        'return' => array( // Array from found tags.
+                            array( // First found tag.
+                                array(array('\SingleClass', false), array('\MultipleClass', true)), // Array from data types.
+                                'Return Description',
+                            )
+                        )
+                    )
+                ),
+            ),
+            array('
+               /**
+                * @author Author Name
+                * @covers SomeClass::SomeMethod
+                * @deprecated 1.0 for ever
+                * @example Description
+                * @link http://www.google.com
+                * @method void setInteger(integer $integer)
+                * @property-read string $myProperty
+                * @property string $myProperty
+                * @property-write string $myProperty
+                * @see SomeClass::SomeMethod
+                * @since 1.0.1 First time this was introduced.
+                * @source 2 1 Check that ensures lazy counting.
+                * @uses MyClass::$items to retrieve the count from.
+                * @version 1.0.1
+                * @unknown any text
+                */
+               ',
+                array(
+                    'tags' => array(
+                        'author' => array('Author Name'),
+                        'covers' => array('SomeClass::SomeMethod'),
+                        'deprecated' => array('1.0 for ever'),
+                        'example' => array('Description'),
+                        'link' => array('http://www.google.com'),
+                        'method' => array('void setInteger(integer $integer)'),
+                        'property-read' => array('string $myProperty'),
+                        'property' => array('string $myProperty'),
+                        'property-write' => array('string $myProperty'),
+                        'see' => array('SomeClass::SomeMethod'),
+                        'since' => array('1.0.1 First time this was introduced.'),
+                        'source' => array('2 1 Check that ensures lazy counting.'),
+                        'uses' => array('MyClass::$items to retrieve the count from.'),
+                        'version' => array('1.0.1'),
+                        'unknown' => array('any text'),
+                    )
+                ),
+           ),
         );
     }
 


### PR DESCRIPTION
Adding tests to verify, that each of 19 supports tags in DocBlocks are parsed as expected.

Before tests were added the error during `@method` and `@property*` wasn't discovered in time, when #101 was implemented. Now all should work fine.

Closes #108
