### PR TITLE
Don't update Composer on each buld

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
   - hhvm
 
 before_script:
-  - composer self-update
   - composer install --no-interaction --prefer-source --dev
 
 script: phpunit


### PR DESCRIPTION
Currently at least 1 of builds in build matrix fails because of `composer self-update` command in the `.travis.yml`. See https://travis-ci.org/fabpot/Sami/jobs/30440724

I've removed it since I haven't witnessed a case, that even month old `composer.phar` has created problems during a build.
