### PR TITLE
Showing namespaces on each namespace page.

### DIFF
--- a/Sami/Project.php
+++ b/Sami/Project.php
@@ -225,6 +225,23 @@ class Project
         return $this->namespaceInterfaces[$namespace];
     }
 
+    public function getNamespaceSubNamespaces($parent)
+    {
+        $prefix = strlen($parent) ? ($parent . '\\') : '';
+        $len = strlen($prefix);
+        $namespaces = array();
+
+        foreach ($this->namespaces as $sub) {
+            if (substr($sub, 0, $len) == $prefix
+                && strpos(substr($sub, $len), '\\') === false
+            ) {
+                $namespaces[] = $sub;
+            }
+        }
+
+        return $namespaces;
+    }
+
     public function addClass(ClassReflection $class)
     {
         $this->classes[$class->getName()] = $class;

--- a/Sami/Renderer/Renderer.php
+++ b/Sami/Renderer/Renderer.php
@@ -134,10 +134,11 @@ class Renderer
             }
 
             $variables = array(
-                'namespace'  => $namespace,
-                'classes'    => $project->getNamespaceClasses($namespace),
-                'interfaces' => $project->getNamespaceInterfaces($namespace),
-                'exceptions' => $project->getNamespaceExceptions($namespace),
+                'namespace'     => $namespace,
+                'subnamespaces' => $project->getNamespaceSubNamespaces($namespace),
+                'classes'       => $project->getNamespaceClasses($namespace),
+                'interfaces'    => $project->getNamespaceInterfaces($namespace),
+                'exceptions'    => $project->getNamespaceExceptions($namespace),
             );
             foreach ($this->theme->getTemplates('namespace') as $template => $target) {
                 $this->save($project, sprintf($target, str_replace('\\', '/', $namespace)), $template, $variables);

--- a/Sami/Resources/themes/default/namespace.twig
+++ b/Sami/Resources/themes/default/namespace.twig
@@ -20,7 +20,16 @@
 {% block content %}
     <h1>{{ namespace_link(namespace, {'target': 'main'}) }}</h1>
 
+    {% if subnamespaces %}
+        <h2>Namespaces</h2>
+        {% for ns in subnamespaces %}
+            {{ namespace_link(ns, {'target': 'main'}) }}
+            {%- if not loop.last -%}, {%- endif -%}
+        {% endfor %}
+    {% endif %}
+
     {% if classes %}
+        <h2>Classes</h2>
         <ul>
             {% for class in classes %}
                 <li>{{ class_link(class, {'target': 'main'}) }}</li>

--- a/Sami/Resources/themes/default/pages/namespace.twig
+++ b/Sami/Resources/themes/default/pages/namespace.twig
@@ -1,6 +1,6 @@
 {% extends page_layout %}
 
-{% from "macros.twig" import class_link %}
+{% from "macros.twig" import class_link, namespace_link %}
 
 {% block title %}{{ namespace }} | {{ parent() }}{% endblock %}
 
@@ -12,7 +12,17 @@
 {% endblock %}
 
 {% block content %}
+
+    {% if subnamespaces %}
+        <h2>Namespaces</h2>
+        {% for ns in subnamespaces %}
+            {{ namespace_link(ns, {'target': 'main'}) }}
+            {%- if not loop.last -%}, {%- endif -%}
+        {% endfor %}
+    {% endif %}
+
     {% if classes %}
+        <h2>Classes</h2>
         <table>
             {% for class in classes %}
                 <tr>


### PR DESCRIPTION
This commit builds on top of PR https://github.com/fabpot/Sami/pull/13,
but it has been updated for recent changes to Sami. In addition to
some minor tweaks, this PR shows child namespaces as a comma separated
list of namespaces rather than in a table to take up less space. This
allows users to see classes and interfaces on a page without having
to scroll down past the fold (providing a better user experience IMO).

Closes #13. Closes #119.
