### PR TITLE
Incremented nikic/PHP-Parser dependency from v0.9.x to v1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.0",
         "pimple/pimple": "2.*",
         "twig/twig": "1.*",
-        "nikic/php-parser": "0.9.*",
+        "nikic/php-parser": "~1.0",
         "michelf/php-markdown": "~1.3",
         "symfony/console": "~2.1",
         "symfony/finder": "~2.1",


### PR DESCRIPTION
# Changes
- Increment [php-parser](https://github.com/nikic/PHP-Parser) dependency from `0.9.*` to `~1.0`
# Reasons
- Version `0.9.x` of [php-parser](https://github.com/nikic/PHP-Parser) is [no longer maintainer](https://github.com/nikic/PHP-Parser#php-parser)
- Version `0.9.x` cannot handle newer [PHP 5.6 features](http://php.net/ChangeLog-5.php#5.6.0)
  - Example being [variadic function arguments](http://php.net/manual/en/functions.arguments.php#functions.variable-arg-list) which cause a lexer error with version `0.9.x`
- All PHPUnit tests pass with the change to version `1.0.1`
