### PR TITLE
Updated The Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 language: php
 
 php:
+  - 5.3.3
   - 5.3
   - 5.4
   - 5.5
   - 5.6
   - hhvm
 
-before_script:
-  - composer install --no-interaction --prefer-source --dev
+install:
+  - travis_retry composer install --no-interaction --prefer-source
 
-script: phpunit
-
-matrix:
-  allow_failures:
-    - php: hhvm
-  fast_finish: true
+script:
+  - phpunit


### PR DESCRIPTION
- Let's run the test on php 5.3.3 too since we are supposed to support it.
- The composer install should take place under `install` rather than `before_script`.
- I've wrapped the composer install in `travis_retry` so that if there is a networking issue causing a failed download, then travis will retry the command upto 3 times before giving up.
- I've removed the `--dev` flag from the composer install since it's obsolte - composer will install dev-dependencies by default, and we don't even have any dev-dependencies anyway.
- I've removed hhvm from `allow_failures` since the test suite has been passing on hhvm for a long time.
