### PR TITLE
Fix NULL being added to ParserContext classes

### DIFF
--- a/Sami/Parser/ParserContext.php
+++ b/Sami/Parser/ParserContext.php
@@ -110,6 +110,9 @@ class ParserContext
 
     public function leaveClass()
     {
+        if (!isset($this->class)) {
+            return;
+        }
         $this->classes[] = $this->class;
         $this->class = null;
     }

--- a/Sami/Parser/ParserContext.php
+++ b/Sami/Parser/ParserContext.php
@@ -110,7 +110,7 @@ class ParserContext
 
     public function leaveClass()
     {
-        if (!isset($this->class)) {
+        if (null === $this->class) {
             return;
         }
 

--- a/Sami/Parser/ParserContext.php
+++ b/Sami/Parser/ParserContext.php
@@ -113,6 +113,7 @@ class ParserContext
         if (!isset($this->class)) {
             return;
         }
+
         $this->classes[] = $this->class;
         $this->class = null;
     }

--- a/Sami/Tests/Parser/ParserContextTest.php
+++ b/Sami/Tests/Parser/ParserContextTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Sami\Tests\Parser;
+
+use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
+use Sami\Parser\DocBlockParser;
+use Sami\Parser\Filter\TrueFilter;
+use Sami\Parser\ParserContext;
+use Sami\Reflection\ClassReflection;
+
+class ParserContextTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLeaveClassBeforeEnter()
+    {
+        $filter = new TrueFilter();
+        $docBlockParser = new DocBlockParser();
+        $prettyPrinter = new PrettyPrinter();
+
+        $context = new ParserContext($filter, $docBlockParser, $prettyPrinter);
+        $class = new ClassReflection('C1', 1);
+
+        $context->enterFile(null, null);
+
+        // Leave a class before entering it
+        $context->leaveClass();
+
+        // Genuinely enter and leave a class
+        $context->enterClass($class);
+        $context->leaveClass();
+
+        $classes = $context->leaveFile();
+
+        $this->assertContainsOnlyInstancesOf(
+            'Sami\Reflection\ClassReflection',
+            $classes
+        );
+    }
+}

--- a/Sami/Tests/Parser/ParserContextTest.php
+++ b/Sami/Tests/Parser/ParserContextTest.php
@@ -30,9 +30,6 @@ class ParserContextTest extends \PHPUnit_Framework_TestCase
 
         $classes = $context->leaveFile();
 
-        $this->assertContainsOnlyInstancesOf(
-            'Sami\Reflection\ClassReflection',
-            $classes
-        );
+        $this->assertContainsOnlyInstancesOf('Sami\Reflection\ClassReflection', $classes);
     }
 }


### PR DESCRIPTION
Fixes bug referenced by ezzatron in https://github.com/FriendsOfPHP/Sami/issues/99#issuecomment-57895131. NULL was being added to the ParserContext classes array because of a complicated chain of events in PHP-Parser that resulted in `leaveClass` getting called without a matching `enterClass`. This doesn't fix the root cause, but it does allow for filtering out classes (ie. if SymfonyFilter is used).