### PR TITLE
Fixes a bug with the height of the api-tree in the default theme

### DIFF
--- a/Sami/Resources/themes/default/css/sami.css
+++ b/Sami/Resources/themes/default/css/sami.css
@@ -60,6 +60,8 @@ html, body, #content {
     border-right: 1px solid #ccc;
     line-height: 18px;
     font-size: 13px;
+    display: flex;
+    flex-flow: column;
 }
 
 @media (max-width: 991px) {


### PR DESCRIPTION
The api tree in the left column of the default theme has a CSS height of `100%`. Because of the search form and version switcher at the top of the left column, the api tree is too high and can't be scrolled completely down, leaving the items displayed at the bottom invisible. Take the [Laravel API](http://laravel.com/api/5.0/index.html) for example:

![screen shot 2015-02-16 at 19 37 58-arrow](https://cloud.githubusercontent.com/assets/2457311/6217406/c7861768-b613-11e4-9593-1f4768e74e9e.png)

I fixed the issue using a CSS flexbox while remaining fully compatible to browsers not supporting flexbox (those have to live with the invisible items).

See the fix applied to the example from above:
![screen shot 2015-02-16 at 19 38 31](https://cloud.githubusercontent.com/assets/2457311/6217416/e8d43ff8-b613-11e4-9a77-c55bf26b7f48.png)
