### PR TITLE
Now printing class name on method error

### DIFF
--- a/Sami/Parser/NodeVisitor.php
+++ b/Sami/Parser/NodeVisitor.php
@@ -56,7 +56,7 @@ class NodeVisitor extends NodeVisitorAbstract
         } elseif ($this->context->getClass() && $node instanceof PropertyNode) {
             $this->addProperty($node);
         } elseif ($this->context->getClass() && $node instanceof ClassMethodNode) {
-            $this->addMethod($node);
+            $this->addMethod($node, $this->context->getClass());
         } elseif ($this->context->getClass() && $node instanceof ClassConstNode) {
             $this->addConstant($node);
         }
@@ -137,9 +137,10 @@ class NodeVisitor extends NodeVisitorAbstract
         return $class;
     }
 
-    protected function addMethod(ClassMethodNode $node)
+    protected function addMethod(ClassMethodNode $node, ClassReflection $class)
     {
         $method = new MethodReflection($node->name, $node->getLine());
+        $method->setClass($class);
         $method->setModifiers((string) $node->type);
 
         $method->setByRef((string) $node->byRef);

--- a/Sami/Parser/NodeVisitor.php
+++ b/Sami/Parser/NodeVisitor.php
@@ -56,7 +56,7 @@ class NodeVisitor extends NodeVisitorAbstract
         } elseif ($this->context->getClass() && $node instanceof PropertyNode) {
             $this->addProperty($node);
         } elseif ($this->context->getClass() && $node instanceof ClassMethodNode) {
-            $this->addMethod($node, $this->context->getClass());
+            $this->addMethod($node);
         } elseif ($this->context->getClass() && $node instanceof ClassConstNode) {
             $this->addConstant($node);
         }
@@ -137,10 +137,10 @@ class NodeVisitor extends NodeVisitorAbstract
         return $class;
     }
 
-    protected function addMethod(ClassMethodNode $node, ClassReflection $class)
+    protected function addMethod(ClassMethodNode $node)
     {
         $method = new MethodReflection($node->name, $node->getLine());
-        $method->setClass($class);
+        $method->setClass($this->context->getClass());
         $method->setModifiers((string) $node->type);
 
         $method->setByRef((string) $node->byRef);


### PR DESCRIPTION
fixes #147

When a method error was printed, the `MethodReflection` did not have a
`ClassReflection` associated with it. Now, the classname is printed as
part of the error, because the class is set on the `MethodReflection`

Signed-off-by: Martin Schenck <herrschenck@gmail.com>