### PR TITLE
Adding a fix to parse the contents of a file rather than trying to parse a filename

### DIFF
--- a/Sami/Renderer/ThemeSet.php
+++ b/Sami/Renderer/ThemeSet.php
@@ -37,7 +37,8 @@ class ThemeSet
         $this->themes = array();
         $parents = array();
         foreach (Finder::create()->name('manifest.yml')->in($dirs) as $manifest) {
-            $config = Yaml::parse($manifest);
+            $text = file_get_contents($manifest);
+            $config = Yaml::parse($text);
             if (!isset($config['name'])) {
                 throw new \InvalidArgumentException(sprintf('Theme manifest in "%s" must have a "name" entry.', $manifest));
             }


### PR DESCRIPTION
This PR closes #160 to ensure that Sami parses the contents of a yaml file rather than trying to parse the filename of a yaml file.