### PR TITLE
Add responsive meta tags.

### DIFF
--- a/Sami/Resources/themes/default/layout/base.twig
+++ b/Sami/Resources/themes/default/layout/base.twig
@@ -13,6 +13,9 @@
         <script src="{{ path('js/bootstrap.min.js') }}"></script>
         <script src="{{ path('js/typeahead.min.js') }}"></script>
         <script src="{{ path('sami.js') }}"></script>
+        <meta name="MobileOptimized" content="width">
+        <meta name="HandheldFriendly" content="true">
+        <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1">
     {% endblock %}
 
     {% if project.config('favicon') %}


### PR DESCRIPTION
Without these tags the responsive works on desktop but not on mobile. I only tested this on an S5 but I presume other devices would have similar issues.