### PR TITLE
Fix for wrong slashes on Windows

### DIFF
--- a/Sami/RemoteRepository/GitHubRemoteRepository.php
+++ b/Sami/RemoteRepository/GitHubRemoteRepository.php
@@ -15,7 +15,7 @@ class GitHubRemoteRepository extends AbstractRemoteRepository
 {
     public function getFileUrl($projectVersion, $relativePath, $line)
     {
-        $url = 'https://github.com/'.$this->name.'/blob/'.str_replace('\\', '/',$projectVersion.$relativePath);
+        $url = 'https://github.com/'.$this->name.'/blob/'.str_replace('\\', '/', $projectVersion.$relativePath);
 
         if (null !== $line) {
             $url .= '#L'.(int) $line;

--- a/Sami/RemoteRepository/GitHubRemoteRepository.php
+++ b/Sami/RemoteRepository/GitHubRemoteRepository.php
@@ -15,7 +15,7 @@ class GitHubRemoteRepository extends AbstractRemoteRepository
 {
     public function getFileUrl($projectVersion, $relativePath, $line)
     {
-        $url = 'https://github.com/'.$this->name.'/blob/'.$projectVersion.$relativePath;
+        $url = 'https://github.com/'.$this->name.'/blob/'.str_replace('\\', '/',$projectVersion.$relativePath);
 
         if (null !== $line) {
             $url .= '#L'.(int) $line;


### PR DESCRIPTION
It was generating links for Github with back-slashes instead of forward-slashes on my PC.