### PR TITLE
Improve parsing speed when cache is available

### DIFF
--- a/Sami/Parser/ClassVisitor/InheritdocClassVisitor.php
+++ b/Sami/Parser/ClassVisitor/InheritdocClassVisitor.php
@@ -29,40 +29,40 @@ class InheritdocClassVisitor implements ClassVisitorInterface
                     continue;
                 }
 
-                if (!$parameter->getShortDesc()) {
+                if ($parameter->getShortDesc() != $parentParameter->getShortDesc()) {
                     $parameter->setShortDesc($parentParameter->getShortDesc());
                     $modified = true;
                 }
 
-                if (!$parameter->getHint()) {
+                if ($parameter->getHint() != $parentParameter->getRawHint()) {
                     // FIXME: should test for a raw hint from tags, not the one from PHP itself
                     $parameter->setHint($parentParameter->getRawHint());
                     $modified = true;
                 }
             }
 
-            if (!$method->getHint()) {
+            if ($method->getHint() != $parentMethod->getRawHint()) {
                 $method->setHint($parentMethod->getRawHint());
                 $modified = true;
             }
 
-            if (!$method->getHintDesc()) {
+            if ($method->getHintDesc() != $parentMethod->getHintDesc()) {
                 $method->setHintDesc($parentMethod->getHintDesc());
                 $modified = true;
             }
 
             if ('{@inheritdoc}' == strtolower(trim($method->getShortDesc())) || !$method->getDocComment()) {
-                if (!$method->getShortDesc()) {
+                if ($method->getShortDesc() != $parentMethod->getShortDesc()) {
                     $method->setShortDesc($parentMethod->getShortDesc());
                     $modified = true;
                 }
 
-                if (!$method->getLongDesc()) {
+                if ($method->getLongDesc() != $parentMethod->getLongDesc()) {
                     $method->setLongDesc($parentMethod->getLongDesc());
                     $modified = true;
                 }
 
-                if (!$method->getExceptions()) {
+                if ($method->getExceptions() != $parentMethod->getRawExceptions()) {
                     $method->setExceptions($parentMethod->getRawExceptions());
                     $modified = true;
                 }

--- a/Sami/Parser/ClassVisitor/ViewSourceClassVisitor.php
+++ b/Sami/Parser/ClassVisitor/ViewSourceClassVisitor.php
@@ -29,7 +29,7 @@ class ViewSourceClassVisitor implements ClassVisitorInterface
     {
         $filePath = $this->remoteRepository->getRelativePath($class->getFile());
 
-        if ('' !== $filePath) {
+        if ($class->getRelativeFilePath() != $filePath) {
             $class->setRelativeFilePath($filePath);
 
             return true;

--- a/Sami/Parser/Parser.php
+++ b/Sami/Parser/Parser.php
@@ -38,6 +38,7 @@ class Parser
         $steps = iterator_count($this->iterator);
         $context = $this->parser->getContext();
         $transaction = new Transaction($project);
+        $toStore = new \SplObjectStorage();
         foreach ($this->iterator as $file) {
             ++$step;
 
@@ -62,7 +63,8 @@ class Parser
 
                 $project->addClass($class);
                 $transaction->addClass($class);
-                $this->store->writeClass($project, $class);
+                $toStore->attach($class);
+                $class->notFromCache();
             }
         }
 
@@ -73,8 +75,9 @@ class Parser
         }
 
         // visit each class for stuff that can only be done when all classes are parsed
-        $modified = $this->traverser->traverse($project);
-        foreach ($modified as $class) {
+        $toStore->addAll($this->traverser->traverse($project));
+
+        foreach ($toStore as $class) {
             $this->store->writeClass($project, $class);
         }
 

--- a/Sami/Reflection/ClassReflection.php
+++ b/Sami/Reflection/ClassReflection.php
@@ -43,6 +43,7 @@ class ClassReflection extends Reflection
     protected $projectClass = true;
     protected $aliases = array();
     protected $errors = array();
+    protected $fromCache = false;
 
     public function __toString()
     {
@@ -436,6 +437,16 @@ class ClassReflection extends Reflection
         $this->errors = $errors;
     }
 
+    public function isFromCache()
+    {
+        return $this->fromCache;
+    }
+
+    public function notFromCache()
+    {
+        $this->fromCache = false;
+    }
+
     public function toArray()
     {
         return array(
@@ -475,6 +486,7 @@ class ClassReflection extends Reflection
         $class->file = $array['file'];
         $class->relativeFilePath = $array['relative_file'];
         $class->modifiers = $array['modifiers'];
+        $class->fromCache = true;
         if ($array['is_interface']) {
             $class->setInterface(true);
         }

--- a/Sami/Sami.php
+++ b/Sami/Sami.php
@@ -35,7 +35,7 @@ use Sami\Version\Version;
 
 class Sami extends Container
 {
-    const VERSION = '3.0.7-DEV';
+    const VERSION = '3.1.0-DEV';
 
     public function __construct($iterator = null, array $config = array())
     {


### PR DESCRIPTION
While fixing some bugs on Sami, I spent some time measuring Sami speed with Blackfire. For now, I've just analyzed the parsing phase, and this is the first optimization pass based on what I've seen on Blackfire.

I can see a 25/30% speed improvement over Twig or Symfony when cache is there:

https://blackfire.io/profiles/compare/d8aa0168-ed7a-4721-8695-cd86b051b6c7/graph

and a negligible impact when cache is not available:

https://blackfire.io/profiles/compare/1a4d0266-60fb-4c4e-abd4-576ea0f76d51/graph

The speed-up comes from:

* Not storing the same class more than once;
* Not visiting classes when they come from the cache are were not modified (or their parent/interfaces).

