### PR TITLE
Add a link to class methods if a remote repository is configured

### DIFF
--- a/Sami/Reflection/MethodReflection.php
+++ b/Sami/Reflection/MethodReflection.php
@@ -148,6 +148,11 @@ class MethodReflection extends Reflection
         $this->errors = $errors;
     }
 
+    public function getSourcePath()
+    {
+        return $this->class->getSourcePath($this->line);
+    }
+
     public function toArray()
     {
         return array(

--- a/Sami/Resources/themes/default/class.twig
+++ b/Sami/Resources/themes/default/class.twig
@@ -1,5 +1,5 @@
 {% extends "layout/layout.twig" %}
-{% from "macros.twig" import render_classes, breadcrumbs, namespace_link, class_link, property_link, method_link, hint_link, source_link %}
+{% from "macros.twig" import render_classes, breadcrumbs, namespace_link, class_link, property_link, method_link, hint_link, source_link, method_source_link %}
 {% block title %}{{ class.name }} | {{ parent() }}{% endblock %}
 {% block body_class 'class' %}
 {% block page_id 'class:' ~ (class.name|replace({'\\': '_'})) %}
@@ -213,7 +213,7 @@
 
 {% block method %}
     <h3 id="method_{{ method.name }}">
-        <div class="location">{% if method.class is not same as(class) %}in {{ method_link(method, false, true) }} {% endif %}at line {{ method.line }}</div>
+        <div class="location">{% if method.class is not same as(class) %}in {{ method_link(method, false, true) }} {% endif %}at {{ method_source_link(method) }}</div>
         <code>{{ block('method_signature') }}</code>
     </h3>
     <div class="details">

--- a/Sami/Resources/themes/default/macros.twig
+++ b/Sami/Resources/themes/default/macros.twig
@@ -52,6 +52,14 @@
     {%- endif %}
 {%- endmacro %}
 
+{% macro method_source_link(method) -%}
+    {% if method.sourcepath %}
+        <a href="{{ method.sourcepath }}">line {{ method.line }}</a>
+    {%- else %}
+        line {{ method.line }}
+    {%- endif %}
+{%- endmacro %}
+
 {% macro abbr_class(class, absolute) -%}
     <abbr title="{{ class }}">{{ absolute|default(false) ? class : class.shortname }}</abbr>
 {%- endmacro %}


### PR DESCRIPTION
The link will be shown as the "at line ###" part for each method.
![link](https://cloud.githubusercontent.com/assets/2457311/10710148/7ee1c41a-7a4b-11e5-9092-d39b46f0435b.png)
Using the link, the users can directly jump to the method source.

This is an extension of #91