### PR TITLE
Handle FQCN parsed parameter as it

### DIFF
--- a/Sami/Parser/NodeVisitor.php
+++ b/Sami/Parser/NodeVisitor.php
@@ -12,6 +12,7 @@
 namespace Sami\Parser;
 
 use PhpParser\Node as AbstractNode;
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Node\Stmt as StmtNode;
 use PhpParser\Node\Stmt\ClassConst as ClassConstNode;
@@ -151,8 +152,13 @@ class NodeVisitor extends NodeVisitorAbstract
             if ($param->default) {
                 $parameter->setDefault($this->context->getPrettyPrinter()->prettyPrintExpr($param->default));
             }
-            if ((string) $param->type) {
-                $parameter->setHint($this->resolveHint(array(array((string) $param->type, false))));
+
+            if ($type = (string) $param->type) {
+                if ($param->type instanceof FullyQualified && strpos($type, '\\') !== 0) {
+                    $type = '\\'.$type;
+                }
+
+                $parameter->setHint($this->resolveHint(array(array($type, false))));
             }
             $method->addParameter($parameter);
         }


### PR DESCRIPTION
A `PhpParser\Node\Name\FullyQualified` parsed parameter type is not handle like it must be. The `resolveAlias` method check for the `\\` prefix which is missing here so we got a wrong alias.

Now, the parameter parsed type is checked to add the prefix when necessary.

Work on #194