### PR TITLE
Defaulting to ./sami.cfg.php if not passed a config

### DIFF
--- a/Sami/Console/Command/Command.php
+++ b/Sami/Console/Command/Command.php
@@ -41,7 +41,7 @@ abstract class Command extends BaseCommand
      */
     protected function configure()
     {
-        $this->getDefinition()->addArgument(new InputArgument('config', InputArgument::REQUIRED, 'The configuration'));
+        $this->getDefinition()->addArgument(new InputArgument('config', InputArgument::OPTIONAL, 'The configuration (Defaults to sami.cfg.php)'));
         $this->getDefinition()->addOption(new InputOption('only-version', '', InputOption::VALUE_REQUIRED, 'The version to build'));
     }
 
@@ -51,6 +51,11 @@ abstract class Command extends BaseCommand
         $this->output = $output;
 
         $config = $input->getArgument('config');
+
+        if ($config == '') {
+            $config = 'sami.cfg.php';
+        }
+
         $filesystem = new Filesystem();
 
         if (!$filesystem->isAbsolutePath($config)) {


### PR DESCRIPTION
Simple edit for defaulting to using the config file in the cwd if not given one.
