### PR TITLE
Fix issue #158

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/filesystem": "~2.1",
         "symfony/yaml": "~2.1",
         "symfony/process": "~2.1",
+        "symfony/event-dispatcher": "~2.1",
         "phpdocumentor/reflection-docblock": "~2.0",
         "blackfire/php-sdk": "^1.5.6"
     },


### PR DESCRIPTION
When building the documentation of a project defining a ConsoleExceptionListener (like described in http://symfony.com/doc/current/cookbook/console/logging.html#enabling-automatic-exceptions-logging) we got this issue:

```
Version master
  Rendering ############################################# 91%     
            Class PTC\CoreBundle\Listener\ConsoleExceptionListener
PHP Fatal error:  Class 'Symfony\Component\EventDispatcher\Event' not found in phar:///.../sami.phar/vendor/symfony/console/Event/ConsoleEvent.php on line 25
```

By adding a dependency to "symfony/event-dispatcher", there is no more issue. Maybe not the best way to fix the issue as not directly needed by Sami but it does the trick as a tempoary solution? See https://github.com/FriendsOfPHP/Sami/issues/158 for more details.