### PR TITLE
Tree parser sets links for namespaces containing sub namespaces

### DIFF
--- a/Sami/Tests/Parser/ClassTraverserTest.php
+++ b/Sami/Tests/Parser/ClassTraverserTest.php
@@ -55,7 +55,7 @@ class ClassTraverserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expectedNamespaces, $project->getNamespaces());
     }
-    
+
     public function getTraverseOrderClasses()
     {
         // as classes are sorted by name in Project, we try all combinaison
@@ -69,13 +69,13 @@ class ClassTraverserTest extends \PHPUnit_Framework_TestCase
             $this->createClasses('C3', 'C2', 'C1'),
         );
     }
-    
+
     public function getNamespaceDetectionClasses()
     {
         return array(
-            array_merge($this->createClasses('C1', 'C2', 'C3'), array(array(""))),
-            array_merge($this->createClasses('C1', 'C2', 'C3', "Ns1"), array(array("", "Ns1"))),
-            array_merge($this->createClasses('C1', 'C2', 'C3', "Ns1\Ns2\Ns3"), array(array("", "Ns1", "Ns1\Ns2", "Ns1\Ns2\Ns3"))),
+            array_merge($this->createClasses('C1', 'C2', 'C3'), array(array(''))),
+            array_merge($this->createClasses('C1', 'C2', 'C3', 'Ns1'), array(array('', 'Ns1'))),
+            array_merge($this->createClasses('C1', 'C2', 'C3', "Ns1\Ns2\Ns3"), array(array('', 'Ns1', "Ns1\Ns2", "Ns1\Ns2\Ns3"))),
         );
     }
 

--- a/Sami/Tests/TreeTest.php
+++ b/Sami/Tests/TreeTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Sami\Tests;
+
+use Sami\Project;
+use Sami\Reflection\ClassReflection;
+use Sami\Store\ArrayStore;
+use Sami\Tree;
+
+/**
+ *
+ * @author Tomasz Struczyński <t.struczynski@gmail.com>
+ */
+class TreeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNamespaces()
+    {
+        $class1 = new ClassReflection('C1', 1);
+        $class2 = new ClassReflection('C2', 1);
+        $class3 = new ClassReflection('C3', 1);
+        $class2->setNamespace('C21');
+        $class3->setNamespace('C31\C32');
+        
+        $store = new ArrayStore();
+        $store->setClasses(array($class1, $class2, $class3));
+
+        $project = new Project($store);
+        $project->loadClass($class1);
+        $project->loadClass($class2);
+        $project->loadClass($class3);
+        
+        $tree = new Tree();
+        
+        $generated = $tree->getTree($project);
+        $this->assertCount(3 ,$generated);
+        
+        $this->assertEquals("[Global Namespace]", $generated[0][0]);
+        $this->assertEquals("", $generated[0][1]);
+        
+        $this->assertEquals("C21", $generated[1][0]);
+        $this->assertEquals("C21", $generated[1][1]);
+        
+        $this->assertEquals("C31", $generated[2][0]);
+        $this->assertEquals("C31", $generated[2][1]);
+        
+        $this->assertCount(3, $generated[2]);
+        $this->assertCount(1, $generated[2][2]);
+        $this->assertEquals("C32", $generated[2][2][0][0]);
+        $this->assertEquals("C31\C32", $generated[2][2][0][1]);
+    }
+}

--- a/Sami/Tests/TreeTest.php
+++ b/Sami/Tests/TreeTest.php
@@ -8,7 +8,6 @@ use Sami\Store\ArrayStore;
 use Sami\Tree;
 
 /**
- *
  * @author Tomasz Struczyński <t.struczynski@gmail.com>
  */
 class TreeTest extends \PHPUnit_Framework_TestCase
@@ -20,7 +19,7 @@ class TreeTest extends \PHPUnit_Framework_TestCase
         $class3 = new ClassReflection('C3', 1);
         $class2->setNamespace('C21');
         $class3->setNamespace('C31\C32');
-        
+
         $store = new ArrayStore();
         $store->setClasses(array($class1, $class2, $class3));
 
@@ -28,24 +27,24 @@ class TreeTest extends \PHPUnit_Framework_TestCase
         $project->loadClass($class1);
         $project->loadClass($class2);
         $project->loadClass($class3);
-        
+
         $tree = new Tree();
-        
+
         $generated = $tree->getTree($project);
         $this->assertCount(3 ,$generated);
-        
-        $this->assertEquals("[Global Namespace]", $generated[0][0]);
-        $this->assertEquals("", $generated[0][1]);
-        
-        $this->assertEquals("C21", $generated[1][0]);
-        $this->assertEquals("C21", $generated[1][1]);
-        
-        $this->assertEquals("C31", $generated[2][0]);
-        $this->assertEquals("C31", $generated[2][1]);
-        
+
+        $this->assertEquals('[Global Namespace]', $generated[0][0]);
+        $this->assertEquals('', $generated[0][1]);
+
+        $this->assertEquals('C21', $generated[1][0]);
+        $this->assertEquals('C21', $generated[1][1]);
+
+        $this->assertEquals('C31', $generated[2][0]);
+        $this->assertEquals('C31', $generated[2][1]);
+
         $this->assertCount(3, $generated[2]);
         $this->assertCount(1, $generated[2][2]);
-        $this->assertEquals("C32", $generated[2][2][0][0]);
+        $this->assertEquals('C32', $generated[2][2][0][0]);
         $this->assertEquals("C31\C32", $generated[2][2][0][1]);
     }
 }

--- a/Sami/Tree.php
+++ b/Sami/Tree.php
@@ -55,7 +55,9 @@ class Tree
             $parts = explode('\\', $namespace);
             $url = '';
             if (!$project->getConfig('simulate_namespaces')) {
-                $url = $parts[count($parts) - 1] && count($cl) ? $namespace : '';
+                $url = $parts[count($parts) - 1]
+                    && $project->hasNamespace($namespace) 
+                    && (count($subnamespaces) || count($cl)) ? $namespace : '';
             }
             $short = $parts[count($parts) - 1] ? $parts[count($parts) - 1] : '[Global Namespace]';
 


### PR DESCRIPTION
Helps with #174 . This may not be a complete fix, as there also should be checks in twig templates. But helps in case when namespace contains no classes, but only subnamespaces.
