### PR TITLE
Use phpDocumentor's parser for "@property" tag parsing

### DIFF
--- a/Sami/Parser/DocBlockParser.php
+++ b/Sami/Parser/DocBlockParser.php
@@ -11,6 +11,7 @@
 
 namespace Sami\Parser;
 
+use phpDocumentor\Reflection\DocBlock\Tag;
 use Sami\Parser\Node\DocBlockNode;
 use phpDocumentor\Reflection\DocBlock;
 
@@ -44,6 +45,11 @@ class DocBlockParser
         }
 
         return $result;
+    }
+
+    public function getTag($string)
+    {
+        return Tag::createInstance($string);
     }
 
     protected function parseTag(DocBlock\Tag $tag)

--- a/Sami/Sami.php
+++ b/Sami/Sami.php
@@ -136,7 +136,7 @@ class Sami extends Container
             $visitors = array(
                 new ClassVisitor\InheritdocClassVisitor(),
                 new ClassVisitor\MethodClassVisitor(),
-                new ClassVisitor\PropertyClassVisitor(),
+                new ClassVisitor\PropertyClassVisitor($sc['parser_context']),
             );
 
             if ($sc['remote_repository'] instanceof AbstractRemoteRepository) {


### PR DESCRIPTION
The built-in code for parsing `@property` tag is now replaced with call to phpDocumentor class (we use it already in other places) to have consistent parsing.

Closes #205