### PR TITLE
The "line" word was shown twice in method line link

### DIFF
--- a/Sami/Resources/themes/default/class.twig
+++ b/Sami/Resources/themes/default/class.twig
@@ -219,7 +219,7 @@
 
 {% block method %}
     <h3 id="method_{{ method.name|raw }}">
-        <div class="location">{% if method.class is not same as(class) %}in {{ method_link(method, false, true) }} {% endif %}at line {{ method_source_link(method) }}</div>
+        <div class="location">{% if method.class is not same as(class) %}in {{ method_link(method, false, true) }} {% endif %}at {{ method_source_link(method) }}</div>
         <code>{{ block('method_signature') }}</code>
     </h3>
     <div class="details">


### PR DESCRIPTION
The `method_source_link` macro already returns `line X` or `<a href="...">line X</a>` and adding one more `line` word in front of it's result is redundant.

![2016-06-25_2053](https://cloud.githubusercontent.com/assets/1277526/16358306/023471ea-3b18-11e6-80ad-62a2f49fa2b3.png)
