### PR TITLE
Fix help messages for update and render commands

### DIFF
--- a/Sami/Console/Command/ParseCommand.php
+++ b/Sami/Console/Command/ParseCommand.php
@@ -33,17 +33,17 @@ class ParseCommand extends Command
 The <info>%command.name%</info> command parses a project and generates a database
 with API information:
 
-    <info>php %command.full_name% parse config/symfony.php</info>
+    <info>php %command.full_name% config/symfony.php</info>
 
 The <comment>--force</comment> option forces a rebuild (it disables the
 incremental parsing algorithm):
 
-    <info>php %command.full_name% parse config/symfony.php --force</info>
+    <info>php %command.full_name% config/symfony.php --force</info>
 
 The <comment>--version</comment> option overrides the version specified
 in the configuration:
 
-    <info>php %command.full_name% parse config/symfony.php --version=master</info>
+    <info>php %command.full_name% config/symfony.php --version=master</info>
 EOF
             );
     }


### PR DESCRIPTION
Before PR:

```php vendor/bin/sami.php parse parse config/symfony.php --force```
...

After PR:

```php vendor/bin/sami.php parse config/symfony.php --force```
...
