### PR TITLE
Optionally allow nikic/php-parser ~2.0 as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.3.9",
         "pimple/pimple": "~3.0",
         "twig/twig": "~1.20|~2.0",
-        "nikic/php-parser": "~1.0",
+        "nikic/php-parser": "~1.0|~2.0",
         "michelf/php-markdown": "~1.3",
         "symfony/console": "~2.1",
         "symfony/finder": "~2.1",


### PR DESCRIPTION
This is related to #217. I encountered conflicts in the attempt to install Sami with a fresh Laravel 5.3 setup.

I wasn't sure what to do with the `composer.lock` in this repo so I left it untouched.