### PR TITLE
upgraded to Symfony 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,8 @@ env:
 
 matrix:
     include:
-        - php: 5.3
-          env: TWIG=1.x
-        - php: 5.4
-          env: TWIG=1.x
         - php: 5.5
+          env: TWIG=1.x
         - php: 5.6
         - php: 5.6
           env: BLACKFIRE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
 language: php
 
-env:
-    global:
-        - TWIG=2.x
-
 matrix:
     include:
         - php: 5.5
-          env: TWIG=1.x
         - php: 5.6
         - php: 5.6
           env: BLACKFIRE=on
@@ -36,11 +31,11 @@ before_install:
             curl -L https://blackfire.io/api/v1/releases/agent/linux/amd64 | tar zxpf -
             chmod 755 agent && ./agent --config=~/.blackfire.ini --socket=unix:///tmp/blackfire.sock &
         fi
-    - if [[ "$TWIG" = "2.x" ]]; then sed -i 's/~1.20|~2.0/~2.0/g' composer.json; composer update; fi
-    - if [[ "$TWIG" = "1.x" ]]; then sed -i 's/~1.20|~2.0/~1.20/g' composer.json; composer update; fi
+
+install:
+    - composer install
 
 before_script:
-    - phpenv config-rm xdebug.ini || true
     - |
         if [[ "$BLACKFIRE" = "on" ]]; then
             curl -L https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$(phpenv version-name | tr -d '.')-zts | tar zxpf -

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@ CHANGELOG
 
 * 4.0.0 (2016-XX-XX)
 
+ * upgraded to PHPParser 3.0 (removed support for 2.x)
+ * removed support for Twig 1.x
  * removed support for PHP 5.3 and 5.4
  * upgraded Symfony to 3.*
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,10 @@
 CHANGELOG
 =========
 
-* 3.3.1 (2016-XX-XX)
+* 4.0.0 (2016-XX-XX)
 
- * n/a
+ * removed support for PHP 5.3 and 5.4
+ * upgraded Symfony to 3.*
 
 * 3.3.0 (2016-06-07)
 

--- a/Sami/Sami.php
+++ b/Sami/Sami.php
@@ -11,10 +11,9 @@
 
 namespace Sami;
 
-use PhpParser\Lexer;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
-use PhpParser\Parser as PhpParser;
+use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Pimple\Container;
 use Sami\Parser\ClassTraverser;
@@ -101,7 +100,7 @@ class Sami extends Container
         };
 
         $this['php_parser'] = function () {
-            return new PhpParser(new Lexer());
+            return (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
         };
 
         $this['php_traverser'] = function ($sc) {

--- a/Sami/Sami.php
+++ b/Sami/Sami.php
@@ -35,7 +35,7 @@ use Sami\Version\Version;
 
 class Sami extends Container
 {
-    const VERSION = '3.3.1-DEV';
+    const VERSION = '4.0.0-DEV';
 
     public function __construct($iterator = null, array $config = array())
     {

--- a/Sami/Tests/IntegrationTest.php
+++ b/Sami/Tests/IntegrationTest.php
@@ -2,13 +2,15 @@
 
 namespace Sami\Tests;
 
-use Blackfire\Client;
+use Blackfire\Bridge\PhpUnit\TestCaseTrait as BlackfireTestCaseTrait;
 use Blackfire\Profile;
 use Sami\Sami;
 use Symfony\Component\Filesystem\Filesystem;
 
 class IntegrationTest extends \PHPUnit_Framework_TestCase
 {
+    use BlackfireTestCaseTrait;
+
     private $bf;
     private $sami;
 
@@ -51,7 +53,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
             ->assert('metrics.sami.storage.read_calls.count <= '.$readCalls, $readCalls.' read calls')
         ;
 
-        $profile = $this->getBlackfireClient()->assertPhpUnit($this, $config, function () use ($sami) {
+        $profile = $this->assertBlackfire($config, function () use ($sami) {
             $sami['project']->parse();
         });
     }
@@ -62,11 +64,6 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
             array(true, 0, 6),
             array(false, 5, 0),
         );
-    }
-
-    private function getBlackfireClient()
-    {
-        return null !== $this->bf ? $this->bf : $this->bf = new Client();
     }
 
     private function clearCache()

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "require": {
         "php": ">=5.5.9",
         "pimple/pimple": "~3.0",
-        "twig/twig": "~1.20|~2.0",
-        "nikic/php-parser": "~1.0",
+        "twig/twig": "~2.0@dev",
+        "nikic/php-parser": "~3.0@dev",
         "michelf/php-markdown": "~1.3",
         "symfony/console": "~3.0",
         "symfony/finder": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
         }
     ],
     "require": {
-        "php": ">=5.3.9",
+        "php": ">=5.5.9",
         "pimple/pimple": "~3.0",
         "twig/twig": "~1.20|~2.0",
         "nikic/php-parser": "~1.0",
         "michelf/php-markdown": "~1.3",
-        "symfony/console": "~2.1",
-        "symfony/finder": "~2.1",
-        "symfony/filesystem": "~2.1",
-        "symfony/yaml": "~2.1",
-        "symfony/process": "~2.1",
+        "symfony/console": "~3.0",
+        "symfony/finder": "~3.0",
+        "symfony/filesystem": "~3.0",
+        "symfony/yaml": "~3.0",
+        "symfony/process": "~3.0",
         "phpdocumentor/reflection-docblock": "~2.0",
         "blackfire/php-sdk": "^1.5.6"
     },
@@ -30,7 +30,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.3-dev"
+            "dev-master": "4.0-dev"
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/yaml": "~3.0",
         "symfony/process": "~3.0",
         "phpdocumentor/reflection-docblock": "~2.0",
-        "blackfire/php-sdk": "^1.5.6"
+        "blackfire/php-sdk": "^1.5.18"
     },
     "autoload": {
         "psr-4": { "Sami\\": "Sami/" }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9fb333eb15a183b5816067452f1f92f7",
-    "content-hash": "e4000561f35e8ea228bb3fd3826fd2f8",
+    "hash": "2a9953e64a4cf5c15e9eb6404ac6f210",
+    "content-hash": "f614f20e2d4e7f70d7707befb8aec31b",
     "packages": [
         {
             "name": "blackfire/php-sdk",
-            "version": "v1.5.15",
+            "version": "v1.5.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/blackfireio/php-sdk.git",
-                "reference": "ace7dd0030332f5c5c7aeecd324efcc6cae9f109"
+                "reference": "384509fc7d377b65da3accc81581db8a5c5d56f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/blackfireio/php-sdk/zipball/ace7dd0030332f5c5c7aeecd324efcc6cae9f109",
-                "reference": "ace7dd0030332f5c5c7aeecd324efcc6cae9f109",
+                "url": "https://api.github.com/repos/blackfireio/php-sdk/zipball/384509fc7d377b65da3accc81581db8a5c5d56f3",
+                "reference": "384509fc7d377b65da3accc81581db8a5c5d56f3",
                 "shasum": ""
             },
             "require": {
@@ -60,26 +60,29 @@
                 "uprofiler",
                 "xhprof"
             ],
-            "time": "2016-05-30 14:34:04"
+            "time": "2016-08-18 10:42:39"
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.0.2",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "a2995e5fe351055f2c7630166af12ce8fd03edfc"
+                "reference": "ec21a59414b99501e723b63fd664aa8ead9c5680"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/a2995e5fe351055f2c7630166af12ce8fd03edfc",
-                "reference": "a2995e5fe351055f2c7630166af12ce8fd03edfc",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/ec21a59414b99501e723b63fd664aa8ead9c5680",
+                "reference": "ec21a59414b99501e723b63fd664aa8ead9c5680",
                 "shasum": ""
             },
             "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
                 "php": "^5.3.2 || ^7.0"
             },
             "require-dev": {
+                "psr/log": "^1.0",
                 "symfony/process": "^2.5 || ^3.0"
             },
             "suggest": {
@@ -115,7 +118,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2016-04-13 10:13:24"
+            "time": "2016-09-04 19:00:06"
         },
         {
             "name": "michelf/php-markdown",
@@ -310,26 +313,26 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.8.7",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5ac8bc9aa77bb2edf06af3a1bb6bc1020d23acd3"
+                "reference": "8ea494c34f0f772c3954b5fbe00bffc5a435e563"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5ac8bc9aa77bb2edf06af3a1bb6bc1020d23acd3",
-                "reference": "5ac8bc9aa77bb2edf06af3a1bb6bc1020d23acd3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8ea494c34f0f772c3954b5fbe00bffc5a435e563",
+                "reference": "8ea494c34f0f772c3954b5fbe00bffc5a435e563",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9",
+                "php": ">=5.5.9",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1|~3.0.0",
-                "symfony/process": "~2.1|~3.0.0"
+                "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/process": "~2.8|~3.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -339,7 +342,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -366,29 +369,29 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 15:06:25"
+            "time": "2016-08-19 06:48:39"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.8.7",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "dee379131dceed90a429e951546b33edfe7dccbb"
+                "reference": "bb29adceb552d202b6416ede373529338136e84f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/dee379131dceed90a429e951546b33edfe7dccbb",
-                "reference": "dee379131dceed90a429e951546b33edfe7dccbb",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/bb29adceb552d202b6416ede373529338136e84f",
+                "reference": "bb29adceb552d202b6416ede373529338136e84f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -415,29 +418,29 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-12 18:01:21"
+            "time": "2016-07-20 05:44:26"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.8.7",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "3ec095fab1800222732ca522a95dce8fa124007b"
+                "reference": "e568ef1784f447a0e54dcb6f6de30b9747b0f577"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/3ec095fab1800222732ca522a95dce8fa124007b",
-                "reference": "3ec095fab1800222732ca522a95dce8fa124007b",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e568ef1784f447a0e54dcb6f6de30b9747b0f577",
+                "reference": "e568ef1784f447a0e54dcb6f6de30b9747b0f577",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -464,7 +467,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 11:11:27"
+            "time": "2016-08-26 12:04:02"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -527,25 +530,25 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.8.7",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "115347d00c342198cdc52a7bd8bc15b5ab43500c"
+                "reference": "e64e93041c80e77197ace5ab9385dedb5a143697"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/115347d00c342198cdc52a7bd8bc15b5ab43500c",
-                "reference": "115347d00c342198cdc52a7bd8bc15b5ab43500c",
+                "url": "https://api.github.com/repos/symfony/process/zipball/e64e93041c80e77197ace5ab9385dedb5a143697",
+                "reference": "e64e93041c80e77197ace5ab9385dedb5a143697",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -572,29 +575,29 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 11:11:27"
+            "time": "2016-08-16 14:58:24"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.8.7",
+            "version": "v3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "815fabf3f48c7d1df345a69d1ad1a88f59757b34"
+                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/815fabf3f48c7d1df345a69d1ad1a88f59757b34",
-                "reference": "815fabf3f48c7d1df345a69d1ad1a88f59757b34",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f291ed25eb1435bddbe8a96caaef16469c2a092d",
+                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -621,20 +624,20 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 11:11:27"
+            "time": "2016-09-02 02:12:52"
         },
         {
             "name": "twig/twig",
-            "version": "v1.24.1",
+            "version": "v1.24.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3566d311a92aae4deec6e48682dc5a4528c4a512"
+                "reference": "33093f6e310e6976baeac7b14f3a6ec02f2d79b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3566d311a92aae4deec6e48682dc5a4528c4a512",
-                "reference": "3566d311a92aae4deec6e48682dc5a4528c4a512",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/33093f6e310e6976baeac7b14f3a6ec02f2d79b7",
+                "reference": "33093f6e310e6976baeac7b14f3a6ec02f2d79b7",
                 "shasum": ""
             },
             "require": {
@@ -682,17 +685,17 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-05-30 09:11:59"
+            "time": "2016-09-01 17:50:53"
         }
     ],
     "packages-dev": [],
     "aliases": [],
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.9"
+        "php": ">=5.5.9"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2a9953e64a4cf5c15e9eb6404ac6f210",
-    "content-hash": "f614f20e2d4e7f70d7707befb8aec31b",
+    "hash": "14a390d6b174c997efc1c7a5dcaa1b0f",
+    "content-hash": "3329c392382cdf874c0c52c367d17046",
     "packages": [
         {
             "name": "blackfire/php-sdk",
@@ -173,32 +173,38 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v1.4.1",
+            "version": "v3.0.0alpha1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51"
+                "reference": "21b18eb2945aa4b887b98a11f0ef7d5fe24527fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51",
-                "reference": "f78af2c9c86107aa1a34cd1dbb5bbe9eeb0d9f51",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/21b18eb2945aa4b887b98a11f0ef7d5fe24527fc",
+                "reference": "21b18eb2945aa4b887b98a11f0ef7d5fe24527fc",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3"
+                "php": ">=5.5"
             },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
-                "files": [
-                    "lib/bootstrap.php"
-                ]
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -214,7 +220,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2015-09-19 14:15:08"
+            "time": "2016-07-25 13:16:35"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -628,20 +634,21 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.24.2",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "33093f6e310e6976baeac7b14f3a6ec02f2d79b7"
+                "reference": "1f831ae9ba0a8d49bcccc5743ae5823a754f6f56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/33093f6e310e6976baeac7b14f3a6ec02f2d79b7",
-                "reference": "33093f6e310e6976baeac7b14f3a6ec02f2d79b7",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/1f831ae9ba0a8d49bcccc5743ae5823a754f6f56",
+                "reference": "1f831ae9ba0a8d49bcccc5743ae5823a754f6f56",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2.7"
+                "php": ">=5.5",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
                 "symfony/debug": "~2.7",
@@ -650,7 +657,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.24-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -685,13 +692,16 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-09-01 17:50:53"
+            "time": "2016-08-25 17:56:11"
         }
     ],
     "packages-dev": [],
     "aliases": [],
-    "minimum-stability": "stable",
-    "stability-flags": [],
+    "minimum-stability": "dev",
+    "stability-flags": {
+        "twig/twig": 20,
+        "nikic/php-parser": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "14a390d6b174c997efc1c7a5dcaa1b0f",
-    "content-hash": "3329c392382cdf874c0c52c367d17046",
+    "hash": "dd7ef21a6ba9362ef78b4c5be3419dd2",
+    "content-hash": "cba8216e6d61854db28c95840870af98",
     "packages": [
         {
             "name": "blackfire/php-sdk",


### PR DESCRIPTION
Upgrading to Symfony 3.0 means : 

* removal of 5.3 and 5.4 support;
* bumping to a new major version.

As we have a new major version, I have also:

* removed support for Twig 1.x;
* upgraded to PHPParser version 3.0.

Fixes #232, #192, #217, #216, and #228