### PR TITLE
build cache broke source link between versions

### DIFF
--- a/Sami/Project.php
+++ b/Sami/Project.php
@@ -486,9 +486,10 @@ class Project
             $this->flushDir($this->getBuildDir());
         }
 
-        if ($previous && !$this->renderer->isRendered($this)) {
+        if ($previous && !$this->renderer->isRendered($this) && $this->getConfig('remote_repository') === NULL ) {
             $this->seedCache($previous, $this->getBuildDir());
         }
+
 
         $diff = $this->renderer->render($this, $callback, $force);
 

--- a/Sami/Project.php
+++ b/Sami/Project.php
@@ -486,7 +486,7 @@ class Project
             $this->flushDir($this->getBuildDir());
         }
 
-        if ($previous && !$this->renderer->isRendered($this) && $this->getConfig('remote_repository') === null ) {
+        if ($previous && !$this->renderer->isRendered($this) && $this->getConfig('remote_repository') === null) {
             $this->seedCache($previous, $this->getBuildDir());
         }
 

--- a/Sami/Project.php
+++ b/Sami/Project.php
@@ -486,10 +486,9 @@ class Project
             $this->flushDir($this->getBuildDir());
         }
 
-        if ($previous && !$this->renderer->isRendered($this) && $this->getConfig('remote_repository') === NULL ) {
+        if ($previous && !$this->renderer->isRendered($this) && $this->getConfig('remote_repository') === null ) {
             $this->seedCache($previous, $this->getBuildDir());
         }
-
 
         $diff = $this->renderer->render($this, $callback, $force);
 


### PR DESCRIPTION
When using remote_repository conf to provide links to gitlab or github source, a class that didn't change from previous version has the same link (that point to previous version).

So, cache should be disabled in this case.
