### PR TITLE
Use JS to select good entry in version dropdown

### DIFF
--- a/Sami/Resources/themes/default/layout/layout.twig
+++ b/Sami/Resources/themes/default/layout/layout.twig
@@ -55,11 +55,14 @@
             <form action="#" method="GET">
                 <select id="version-switcher" name="version">
                     {% for version in project.versions %}
-                        <option value="{{ path('../' ~ version ~ '/index.html') }}"{{ version == project.version ? ' selected' : '' }}>{{ version.longname }}</option>
+                        <option value="{{ path('../' ~ version ~ '/index.html') }}" data-version="{{version}}">{{ version.longname }}</option>
                     {% endfor %}
                 </select>
             </form>
         {% endif %}
+        <script>
+            $('option[data-version="'+window.projectVersion+'"]').attr('selected', true);
+        </script>
         <form id="search-form" action="{{ path('search.html') }}" method="GET">
             <span class="glyphicon glyphicon-search"></span>
             <input name="search"

--- a/Sami/Resources/themes/default/layout/layout.twig
+++ b/Sami/Resources/themes/default/layout/layout.twig
@@ -61,7 +61,7 @@
             </form>
         {% endif %}
         <script>
-            $('option[data-version="'+window.projectVersion+'"]').attr('selected', true);
+            $('option[data-version="'+window.projectVersion+'"]').prop('selected', true);
         </script>
         <form id="search-form" action="{{ path('search.html') }}" method="GET">
             <span class="glyphicon glyphicon-search"></span>

--- a/Sami/Resources/themes/default/sami.js.twig
+++ b/Sami/Resources/themes/default/sami.js.twig
@@ -1,8 +1,6 @@
 {% from _self import element %}
 
-{% block project_version %}
 window.projectVersion = '{{ project.version }}';
-{% endblock %}
 
 (function(root) {
 

--- a/Sami/Resources/themes/default/sami.js.twig
+++ b/Sami/Resources/themes/default/sami.js.twig
@@ -1,5 +1,9 @@
 {% from _self import element %}
 
+{% block project_version %}
+window.projectVersion = '{{ project.version }}';
+{% endblock %}
+
 (function(root) {
 
     var bhIndex = null;


### PR DESCRIPTION
Fixes #121 

If a page is the same between versions, it is not possible to select dropdown entry staticaly.
Let's do it by JavaScript
