### PR TITLE
Adds @todo tag support

### DIFF
--- a/Sami/Reflection/Reflection.php
+++ b/Sami/Reflection/Reflection.php
@@ -146,6 +146,11 @@ abstract class Reflection
         return $this->getTags('deprecated');
     }
 
+    public function getTodo()
+    {
+        return $this->getTags('todo');
+    }
+
     // not serialized as it is only useful when parsing
     public function setDocComment($comment)
     {

--- a/Sami/Resources/themes/default/class.twig
+++ b/Sami/Resources/themes/default/class.twig
@@ -1,5 +1,5 @@
 {% extends "layout/layout.twig" %}
-{% from "macros.twig" import render_classes, breadcrumbs, namespace_link, class_link, property_link, method_link, hint_link, source_link, method_source_link, deprecated, deprecations %}
+{% from "macros.twig" import render_classes, breadcrumbs, namespace_link, class_link, property_link, method_link, hint_link, source_link, method_source_link, deprecated, deprecations, todo, todos %}
 {% block title %}{{ class|raw }} | {{ parent() }}{% endblock %}
 {% block body_class 'class' %}
 {% block page_id 'class:' ~ (class.name|replace({'\\': '_'})) %}
@@ -37,6 +37,9 @@
             {% if class.longdesc -%}
                 <p>{{ class.longdesc|desc(class) }}</p>
             {%- endif %}
+            {% if project.config('insert_todos') == true %}
+                {{ todos(class) }}
+            {% endif %}
         </div>
     {% endif %}
 
@@ -237,6 +240,9 @@
                     <p>{{ method.longdesc|desc(class) }}</p>
                     {%- endif %}
                 {%- endif %}
+                {% if project.config('insert_todos') == true %}
+                    {{ todos(method) }}
+                {% endif %}
             </div>
         {% endif %}
         <div class="tags">

--- a/Sami/Resources/themes/default/macros.twig
+++ b/Sami/Resources/themes/default/macros.twig
@@ -123,3 +123,23 @@
         </p>
     {% endif %}
 {% endmacro %}
+
+{% macro todo(reflection) %}
+        {% if reflection.todo %}<small><sup><span class="label label-info">todo</span></sup></small>{% endif %}
+{% endmacro %}
+
+{% macro todos(reflection) %}
+        {% from _self import todo %}
+
+        {% if reflection.todo %}
+            <p>
+                {{ todo(reflection )}}
+                {% for tag in reflection.todo %}
+                    <tr>
+                        <td>{{ tag[0]|raw }}</td>
+                        <td>{{ tag[1:]|join(' ')|raw }}</td>
+                        </tr>
+                {% endfor %}
+            </p>
+        {% endif %}
+{% endmacro %}

--- a/Sami/Sami.php
+++ b/Sami/Sami.php
@@ -72,6 +72,7 @@ class Sami extends Container
                 'title' => $sc['title'],
                 'source_url' => $sc['source_url'],
                 'source_dir' => $sc['source_dir'],
+                'insert_todos' => $sc['insert_todos'],
             ));
             $project->setRenderer($sc['renderer']);
             $project->setParser($sc['parser']);
@@ -174,6 +175,7 @@ class Sami extends Container
         $this['source_dir'] = '';
         $this['source_url'] = '';
         $this['default_opened_level'] = 2;
+        $this['insert_todos'] = false;
 
         // simulate namespaces for projects based on the PEAR naming conventions
         $this['simulate_namespaces'] = false;

--- a/Sami/Tests/IntegrationTest.php
+++ b/Sami/Tests/IntegrationTest.php
@@ -22,6 +22,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->sami = new Sami(dirname(__DIR__).'/Console', array(
             'build_dir' => $dir.'/build',
             'cache_dir' => $dir.'/cache',
+            'insert_todos' => true,
         ));
     }
 

--- a/Sami/Tests/Parser/DocBlockParserTest.php
+++ b/Sami/Tests/Parser/DocBlockParserTest.php
@@ -181,6 +181,7 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
                 * @author Author Name
                 * @covers SomeClass::SomeMethod
                 * @deprecated 1.0 for ever
+                * @todo Something needs to be done
                 * @example Description
                 * @link http://www.google.com
                 * @method void setInteger(integer $integer)
@@ -200,6 +201,7 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
                         'author' => array('Author Name'),
                         'covers' => array('SomeClass::SomeMethod'),
                         'deprecated' => array('1.0 for ever'),
+                        'todo' => array('Something needs to be done'),
                         'example' => array('Description'),
                         'link' => array('http://www.google.com'),
                         'method' => array('void setInteger(integer $integer)'),

--- a/Sami/Tests/Parser/DocBlockParserTest.php
+++ b/Sami/Tests/Parser/DocBlockParserTest.php
@@ -210,7 +210,7 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
                                 array(              // array of all typehints of one property
                                     array(          // array of one typehint
                                         'string',   // the typehint
-                                        null,// whether or not the typehint is an array
+                                        null,       // whether or not the typehint is an array
                                     ),
                                 ),
                                 'myProperty',       // property name

--- a/Sami/Tests/Parser/DocBlockParserTest.php
+++ b/Sami/Tests/Parser/DocBlockParserTest.php
@@ -210,7 +210,7 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
                                 array(              // array of all typehints of one property
                                     array(          // array of one typehint
                                         'string',   // the typehint
-                                        null// whether or not the typehint is an array
+                                        null,// whether or not the typehint is an array
                                     ),
                                 ),
                                 'myProperty',       // property name


### PR DESCRIPTION
This is a PR for FriendsOfPHP/Sami#263 that adds `@todo` tag support.
Adds a new insert_todos configuration option (disabled by default)
If enabled, @todo tags are parsed and added below class and method descriptions.

Please ignore original commit message, where my brain mixed the strings 'tag' and 'todo' :) 