### PR TITLE
Use Markdown Extra instead of Markdown

### DIFF
--- a/Sami/Renderer/TwigExtension.php
+++ b/Sami/Renderer/TwigExtension.php
@@ -11,7 +11,7 @@
 
 namespace Sami\Renderer;
 
-use Michelf\Markdown;
+use Michelf\MarkdownExtra;
 use Sami\Reflection\ClassReflection;
 use Sami\Reflection\MethodReflection;
 use Sami\Reflection\PropertyReflection;
@@ -111,7 +111,7 @@ class TwigExtension extends \Twig_Extension
         }
 
         if (null === $this->markdown) {
-            $this->markdown = new Markdown();
+            $this->markdown = new MarkdownExtra();
         }
 
         // FIXME: the @see argument is more complex than just a class (Class::Method, local method directly, ...)

--- a/Sami/Resources/themes/default/css/sami.css
+++ b/Sami/Resources/themes/default/css/sami.css
@@ -239,6 +239,28 @@ a abbr {
     cursor: pointer;
 }
 
+.method-description table {
+    border: solid 1px #ccc;
+    padding: 1em;
+    margin: 1em;
+}
+
+.method-description td, .method-description th {
+    padding: 0.75em 1.25em;
+}
+
+.method-description tbody tr:nth-child(even) {
+    background: #edf3fe;
+}
+
+.method-description tbody tr:nth-child(odd) {
+    background: #fff;
+}
+
+.method-description thead tr {
+    background: #edf3fe;
+}
+
 /** General Sami styling **/
 
 .underlined > .row {

--- a/Sami/Resources/themes/default/css/sami.css
+++ b/Sami/Resources/themes/default/css/sami.css
@@ -239,25 +239,29 @@ a abbr {
     cursor: pointer;
 }
 
-.method-description table {
+.method-description table, .description table {
     border: solid 1px #ccc;
     padding: 1em;
     margin: 1em;
 }
 
-.method-description td, .method-description th {
+.method-description td, .method-description th,
+.description td, .description th {
     padding: 0.75em 1.25em;
 }
 
-.method-description tbody tr:nth-child(even) {
+.method-description tbody tr:nth-child(even),
+.description tbody tr:nth-child(even) {
     background: #edf3fe;
 }
 
-.method-description tbody tr:nth-child(odd) {
+.method-description tbody tr:nth-child(odd),
+.description tbody tr:nth-child(odd) {
     background: #fff;
 }
 
-.method-description thead tr {
+.method-description thead tr,
+.description thead tr {
     background: #edf3fe;
 }
 


### PR DESCRIPTION
By using MarkdownExtra, significant extra functionality is made available to users.  For example, it is now possible to format tables within docblocks.

This update does not alter any existing behaviour of sami.

For a full explanation of the extra features available in Markdown Extra, see [https://michelf.ca/projects/php-markdown/extra/](https://michelf.ca/projects/php-markdown/extra/)