### PR TITLE
Fix for incorrect PROJECT_VERSION

### DIFF
--- a/Sami/Project.php
+++ b/Sami/Project.php
@@ -463,10 +463,6 @@ class Project
             $this->store->flushProject($this);
         }
 
-        if ($previous && 0 === count($this->classes)) {
-            $this->seedCache($previous, $this->getCacheDir());
-        }
-
         $transaction = $this->parser->parse($this, $callback);
 
         if (null !== $callback) {
@@ -484,10 +480,6 @@ class Project
 
         if ($force && !$frozen) {
             $this->flushDir($this->getBuildDir());
-        }
-
-        if ($previous && !$this->renderer->isRendered($this)) {
-            $this->seedCache($previous, $this->getBuildDir());
         }
 
         $diff = $this->renderer->render($this, $callback, $force);


### PR DESCRIPTION
I'm using Sami with a config that looks like this:

```
use Sami\Sami;
use Sami\Version\GitVersionCollection;

$versions = GitVersionCollection::create('lib')
    ->addFromTags('v1.0')
    ->add('master', 'master branch')
;

return new Sami('lib', [
    'title' => 'php-activerecord API',
    'theme' => 'php-ar',
    'versions' => $versions,
    'build_dir' => 'build/api/%version%',
    'cache_dir' => 'build/api/cache/%version%',
    'template_dirs' => [
        'docs/sami/themes'
    ]
]);
```

Everything seemed to work at first glance, but I noticed that the little drop-down for selecting a version wouldn't quite seem to work; it would always show the first option in its list as selected, regardless of which version was present in the page url.

I dug around and eventually discovered that the `PROJECT_VERSION` file in both the `cache_dir` and the `build_dir` were the same. More digging led me to calls to `seedCache`; it seems that while building the second version, `master`, it was copying everything from `%build_dir%/cache/v1.0` to `%build_dir%/cache/master`, and everything from `%build_dir%/v1.0` to `%build_dir%/master`. Removing those calls restores everything to working order.

I understand that what I have here is probably not the final fix--those calls to `seedCache` were no doubt added for a reason. Perhaps I'm doing something else wrong?

@fabpot @aik099  please advise!