### PR TITLE
feature #283 Make namespace copyable

### DIFF
--- a/Sami/Resources/themes/default/class.twig
+++ b/Sami/Resources/themes/default/class.twig
@@ -9,7 +9,7 @@
         <div class="namespace-breadcrumbs">
             <ol class="breadcrumb">
                 <li><span class="label label-default">{{ class.categoryName|raw }}</span></li>
-                {{ breadcrumbs(class.namespace) }}
+                {{ breadcrumbs(class.namespace) -}}
                 <li>{{ class.shortname|raw }}</li>
             </ol>
         </div>

--- a/Sami/Resources/themes/default/css/sami.css
+++ b/Sami/Resources/themes/default/css/sami.css
@@ -40,7 +40,10 @@ html, body, #content {
 }
 
 .namespace-breadcrumbs .breadcrumb > li + li:before {
-    content: "\\"
+    content: "";
+}
+.namespace-breadcrumbs .breadcrumb > .backslash {
+    color: #ccc;
 }
 
 /* Site columns */

--- a/Sami/Resources/themes/default/macros.twig
+++ b/Sami/Resources/themes/default/macros.twig
@@ -95,13 +95,13 @@
 {% macro breadcrumbs(namespace) %}
     {% set current_ns = '' %}
     {% for ns in namespace|split('\\') %}
-        {% if current_ns %}
+        {%- if current_ns -%}
             {% set current_ns = current_ns ~ '\\' ~ ns %}
-        {% else %}
+        {%- else -%}
             {% set current_ns = ns %}
-        {% endif %}
-        <li><a href="{{ namespace_path(current_ns) }}">{{ ns|raw }}</a></li>
-    {% endfor %}
+        {%- endif -%}
+        <li><a href="{{ namespace_path(current_ns) }}">{{ ns|raw }}</a></li><li class="backslash">\</li>
+    {%- endfor %}
 {% endmacro %}
 
 {% macro deprecated(reflection) %}


### PR DESCRIPTION
Remove css ::before selector and add li elements with backslashes to make
the breadcrumb copyable.