### PR TITLE
Correct docblock based method parameters

### DIFF
--- a/Sami/Parser/NodeVisitor.php
+++ b/Sami/Parser/NodeVisitor.php
@@ -164,7 +164,7 @@ class NodeVisitor extends NodeVisitorAbstract
             } elseif ($param->type instanceof NullableType) {
                 $type = $param->type->type;
                 $typeStr = (string) $param->type->type;
-            } else {
+            } elseif ($param->type !== null) {
                 $typeStr = (string) $param->type;
             }
 

--- a/Sami/Tests/Parser/NodeVisitorTest.php
+++ b/Sami/Tests/Parser/NodeVisitorTest.php
@@ -156,7 +156,7 @@ class NodeVisitorTest extends \PHPUnit_Framework_TestCase
                 new Param('param1'),
             ),
         ));
-        $method->setDocComment(new \PhpParser\Comment\Doc("/** @param Test\\Class \$param1 */"));
+        $method->setDocComment(new \PhpParser\Comment\Doc('/** @param Test\\Class $param1 */'));
 
         $classReflection->setMethods(array($method));
         $store = new ArrayStore();
@@ -185,7 +185,7 @@ class NodeVisitorTest extends \PHPUnit_Framework_TestCase
                 new Param('param1'),
             ),
         ));
-        $method->setDocComment(new \PhpParser\Comment\Doc("/** @param Test\\Class|string \$param1 */"));
+        $method->setDocComment(new \PhpParser\Comment\Doc('/** @param Test\\Class|string $param1 */'));
 
         $classReflection->setMethods(array($method));
         $store = new ArrayStore();


### PR DESCRIPTION
This fixes #281 - again. This time for docblock based parameters.

I have refactored tests class, so data provider sub functions use main data provider function as a prefix. I have also added tests for docblock based type hints and allowed testing for multiple type hints on one parameter.