### PR TITLE
Add extended support for @see tag

### DIFF
--- a/Sami/Parser/DocBlockParser.php
+++ b/Sami/Parser/DocBlockParser.php
@@ -17,6 +17,12 @@ use Sami\Parser\Node\DocBlockNode;
 
 class DocBlockParser
 {
+    /**
+     * @param mixed $comment
+     * @param ParserContext $context
+     * 
+     * @return DocBlockNode
+     */
     public function parse($comment, ParserContext $context)
     {
         $docBlock = null;
@@ -73,6 +79,15 @@ class DocBlockParser
             case 'ThrowsTag':
                 return array(
                     $tag->getType(),
+                    $tag->getDescription(),
+                );
+            case 'SeeTag':
+                // For backwards compatibility, in first cell we store content.
+                // In second - only a referer for further parsing.
+                // In docblock node we handle this in getOtherTags() method.
+                return array(
+                    $tag->getContent(),
+                    $tag->getReference(),
                     $tag->getDescription(),
                 );
             default:

--- a/Sami/Parser/DocBlockParser.php
+++ b/Sami/Parser/DocBlockParser.php
@@ -18,9 +18,9 @@ use Sami\Parser\Node\DocBlockNode;
 class DocBlockParser
 {
     /**
-     * @param mixed $comment
+     * @param mixed         $comment
      * @param ParserContext $context
-     * 
+     *
      * @return DocBlockNode
      */
     public function parse($comment, ParserContext $context)

--- a/Sami/Parser/Node/DocBlockNode.php
+++ b/Sami/Parser/Node/DocBlockNode.php
@@ -35,6 +35,12 @@ class DocBlockNode
 
         foreach ($tags as $name => $values) {
             foreach ($values as $i => $value) {
+                // For 'see' tag we try to maintain backwards compatibility
+                // by returning only a part of the value.
+                if ($name === 'see') {
+                    $value = $value[0];
+                }
+
                 $tags[$name][$i] = is_string($value) ? explode(' ', $value) : $value;
             }
         }

--- a/Sami/Parser/NodeVisitor.php
+++ b/Sami/Parser/NodeVisitor.php
@@ -363,7 +363,7 @@ class NodeVisitor extends NodeVisitorAbstract
                     $description,
                     $this->resolveAlias($reference),
                     false,
-                    false
+                    false,
                 );
             }
         }

--- a/Sami/Parser/NodeVisitor.php
+++ b/Sami/Parser/NodeVisitor.php
@@ -164,7 +164,7 @@ class NodeVisitor extends NodeVisitorAbstract
             } elseif ($param->type instanceof NullableType) {
                 $type = $param->type->type;
                 $typeStr = (string) $param->type->type;
-            } else {
+            } elseif ($param->type !== null) {
                 $typeStr = (string) $param->type;
             }
 

--- a/Sami/Parser/ParserContext.php
+++ b/Sami/Parser/ParserContext.php
@@ -39,6 +39,9 @@ class ParserContext
         return $this->filter;
     }
 
+    /**
+     * @return DocBlockParser
+     */
     public function getDocBlockParser()
     {
         return $this->docBlockParser;

--- a/Sami/Reflection/Reflection.php
+++ b/Sami/Reflection/Reflection.php
@@ -171,14 +171,14 @@ abstract class Reflection
         $see = array();
         /* @var $project Project */
         $project = $this->getClass()->getProject();
-        
+
         foreach ($this->see as $seeElem) {
             if ($seeElem[3]) {
                 $seeElem = $this->prepareMethodSee($seeElem);
             } elseif ($seeElem[2]) {
                 $seeElem[2] = Project::isPhpTypeHint($seeElem[2]) ? $seeElem[2] : $project->getClass($seeElem[2]);
             }
-            
+
             $see[] = $seeElem;
         }
 
@@ -200,7 +200,7 @@ abstract class Reflection
 
         $class = $project->getClass($seeElem[2]);
         $method = $class->getMethod($seeElem[3]);
-        
+
         if ($method) {
             $seeElem[2] = false;
             $seeElem[3] = $method;

--- a/Sami/Reflection/Reflection.php
+++ b/Sami/Reflection/Reflection.php
@@ -31,6 +31,7 @@ abstract class Reflection
     protected $hintDesc;
     protected $tags;
     protected $docComment;
+    protected $see = array();
 
     public function __construct($name, $line)
     {
@@ -160,5 +161,54 @@ abstract class Reflection
     public function getDocComment()
     {
         return $this->docComment;
+    }
+
+    /**
+     * @return array
+     */
+    public function getSee()
+    {
+        $see = array();
+        /* @var $project Project */
+        $project = $this->getClass()->getProject();
+        
+        foreach ($this->see as $seeElem) {
+            if ($seeElem[3]) {
+                $seeElem = $this->prepareMethodSee($seeElem);
+            } elseif ($seeElem[2]) {
+                $seeElem[2] = Project::isPhpTypeHint($seeElem[2]) ? $seeElem[2] : $project->getClass($seeElem[2]);
+            }
+            
+            $see[] = $seeElem;
+        }
+
+        return $see;
+    }
+
+    /**
+     * @param array $see
+     */
+    public function setSee(array $see)
+    {
+        $this->see = $see;
+    }
+
+    private function prepareMethodSee(array $seeElem)
+    {
+        /* @var $project Project */
+        $project = $this->getClass()->getProject();
+
+        $class = $project->getClass($seeElem[2]);
+        $method = $class->getMethod($seeElem[3]);
+        
+        if ($method) {
+            $seeElem[2] = false;
+            $seeElem[3] = $method;
+        } else {
+            $seeElem[2] = false;
+            $seeElem[3] = false;
+        }
+
+        return $seeElem;
     }
 }

--- a/Sami/Resources/themes/default/class.twig
+++ b/Sami/Resources/themes/default/class.twig
@@ -140,10 +140,20 @@
 
 {% block see %}
     <table class="table table-condensed">
-        {% for tag in method.tags('see') %}
+        {% for see in method.see %}
             <tr>
-                <td>{{ tag[0]|raw }}</td>
-                <td>{{ tag[1:]|join(' ')|raw }}</td>
+                <td>
+                    {% if see[4] %}
+                        <a href="{{see[4]}}">{{see[4]}}</a>
+                    {% elseif see[3] %}
+                        {{ method_link(see[3], false, false) }}
+                    {% elseif see[2] %}
+                        {{ class_link(see[2]) }}
+                    {% else %}
+                        {{ see[0]|raw }}
+                    {% endif %}
+                </td>
+                <td>{{ see[1]|raw }}</td>
             </tr>
         {% endfor %}
     </table>

--- a/Sami/Tests/Parser/DocBlockParserTest.php
+++ b/Sami/Tests/Parser/DocBlockParserTest.php
@@ -84,10 +84,10 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
             ),
             array('
                 /**
-                 * @see http://symfony.com/
+                 * @see http://symfony.com/ This is a link description.
                  */
                 ',
-                array('tags' => array('see' => 'http://symfony.com/')),
+                array('tags' => array('see' => array(array('http://symfony.com/ This is a link description.', 'http://symfony.com/', 'This is a link description.')))),
             ),
             array('
                 /**
@@ -188,7 +188,7 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
                 * @property-read string $myProperty
                 * @property string $myProperty
                 * @property-write string $myProperty
-                * @see SomeClass::SomeMethod
+                * @see SomeClass::SomeMethod This is a description.
                 * @since 1.0.1 First time this was introduced.
                 * @source 2 1 Check that ensures lazy counting.
                 * @uses MyClass::$items to retrieve the count from.
@@ -241,7 +241,7 @@ class DocBlockParserTest extends \PHPUnit_Framework_TestCase
                                 '',
                             ),
                         ),
-                        'see' => array('SomeClass::SomeMethod'),
+                        'see' => array(array('SomeClass::SomeMethod This is a description.', 'SomeClass::SomeMethod', 'This is a description.')),
                         'since' => array('1.0.1 First time this was introduced.'),
                         'source' => array('2 1 Check that ensures lazy counting.'),
                         'uses' => array('MyClass::$items to retrieve the count from.'),

--- a/Sami/Tests/Parser/NodeVisitorTest.php
+++ b/Sami/Tests/Parser/NodeVisitorTest.php
@@ -156,7 +156,7 @@ class NodeVisitorTest extends \PHPUnit_Framework_TestCase
                 new Param('param1'),
             ),
         ));
-        $method->setDocComment(new \PhpParser\Comment\Doc("/** @param Test\\Class \$param1 */"));
+        $method->setDocComment(new \PhpParser\Comment\Doc('/** @param Test\\Class $param1 */'));
 
         $classReflection->setMethods(array($method));
         $store = new ArrayStore();
@@ -185,7 +185,7 @@ class NodeVisitorTest extends \PHPUnit_Framework_TestCase
                 new Param('param1'),
             ),
         ));
-        $method->setDocComment(new \PhpParser\Comment\Doc("/** @param Test\\Class|string \$param1 */"));
+        $method->setDocComment(new \PhpParser\Comment\Doc('/** @param Test\\Class|string $param1 */'));
 
         $classReflection->setMethods(array($method));
         $store = new ArrayStore();


### PR DESCRIPTION
This PR adds extended support for @see tag. It tries to maintain backwards compatibility with templates (see tag is still present in getOtherTags with the same structure, as before). But it is also avaiable as new  `Reflection::getSee()` class method, which adds possibility to create class/method/URL links.