### PR TITLE
Fix typo, add required php version, composer instructions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Curious about what Sami generates? Have a look at the `Symfony API`_.
 Installation
 ------------
 
-Get Sami from as a `phar file`_:
+Get Sami as a `phar file`_:
 
 .. code-block:: bash
 
@@ -18,6 +18,15 @@ without any arguments:
 .. code-block:: bash
 
     $ php sami.phar
+    
+*Note:* Sami 4.0.x requires PHP 7 to work correctly; Sami 3.3.0 can be run with PHP 5.3.9 or higher. 
+
+Install with composer:
+
+.. code-block:: bash
+    
+    $ composer require sami/sami
+    $ php vendor/bin/sami.php
 
 Configuration
 -------------


### PR DESCRIPTION
To help avoid frustrations I ran into with Sami 4 not working correctly (without any error messages) on PHP 5.  Also instructions on how to use composer to install, as an alternative to the .phar.

Also, fixed a typo.