### PR TITLE
Fix Sami for PHP 7.2

### DIFF
--- a/Sami/Version/VersionCollection.php
+++ b/Sami/Version/VersionCollection.php
@@ -15,7 +15,7 @@ use Sami\Project;
 
 abstract class VersionCollection implements \Iterator, \Countable
 {
-    protected $versions;
+    protected $versions = array();
     protected $indice;
     protected $project;
 


### PR DESCRIPTION
This change fixes the Sami for PHP 7.2

Otherwise it fails on PHP 7.2:
> count(): Parameter must be an array or an object that implements Countable