### PR TITLE
Make Sami skip anonymous classes (fixes #294 and #252)

### DIFF
--- a/Sami/Parser/NodeVisitor.php
+++ b/Sami/Parser/NodeVisitor.php
@@ -92,6 +92,11 @@ class NodeVisitor extends NodeVisitorAbstract
 
     protected function addClass(ClassNode $node)
     {
+        // Skip anonymous classes
+        if ($node->isAnonymous()) {
+            return;
+        }
+
         $class = $this->addClassOrInterface($node);
 
         foreach ($node->implements as $interface) {


### PR DESCRIPTION
As discussed on issues #294 and #252, there's a bug in Sami that prevents it generating documentations when it reaches anonymous classes nodes - a feature from PHP 7.x.

As it was never supported before and I'm not sure if it's reasonable to have support for that I'm just proposing this PR to skip those anonymous classes and let Sami works flawlessly as before.