### PR TITLE
Update to phpunit-bridge 4.0

### DIFF
--- a/Sami/Tests/IntegrationTest.php
+++ b/Sami/Tests/IntegrationTest.php
@@ -4,10 +4,11 @@ namespace Sami\Tests;
 
 use Blackfire\Bridge\PhpUnit\TestCaseTrait as BlackfireTestCaseTrait;
 use Blackfire\Profile;
+use PHPUnit\Framework\TestCase;
 use Sami\Sami;
 use Symfony\Component\Filesystem\Filesystem;
 
-class IntegrationTest extends \PHPUnit_Framework_TestCase
+class IntegrationTest extends TestCase
 {
     use BlackfireTestCaseTrait;
 

--- a/Sami/Tests/Parser/ClassTraverserTest.php
+++ b/Sami/Tests/Parser/ClassTraverserTest.php
@@ -11,12 +11,13 @@
 
 namespace Sami\Tests\Parser;
 
+use PHPUnit\Framework\TestCase;
 use Sami\Parser\ClassTraverser;
 use Sami\Project;
 use Sami\Reflection\ClassReflection;
 use Sami\Store\ArrayStore;
 
-class ClassTraverserTest extends \PHPUnit_Framework_TestCase
+class ClassTraverserTest extends TestCase
 {
     /**
      * @dataProvider getTraverseOrderClasses

--- a/Sami/Tests/Parser/ClassVisitor/MethodClassVisitorTest.php
+++ b/Sami/Tests/Parser/ClassVisitor/MethodClassVisitorTest.php
@@ -11,9 +11,10 @@
 
 namespace Sami\Tests\Parser\ClassVisitor;
 
+use PHPUnit\Framework\TestCase;
 use Sami\Parser\ClassVisitor\MethodClassVisitor;
 
-class MethodClassVisitorTest extends \PHPUnit_Framework_TestCase
+class MethodClassVisitorTest extends TestCase
 {
     public function testAddsMethods()
     {

--- a/Sami/Tests/Parser/ClassVisitor/PropertyClassVisitorTest.php
+++ b/Sami/Tests/Parser/ClassVisitor/PropertyClassVisitorTest.php
@@ -11,9 +11,10 @@
 
 namespace Sami\Tests\Parser\ClassVisitor;
 
+use PHPUnit\Framework\TestCase;
 use Sami\Parser\ClassVisitor\PropertyClassVisitor;
 
-class PropertyClassVisitorTest extends \PHPUnit_Framework_TestCase
+class PropertyClassVisitorTest extends TestCase
 {
     public function testAddsProperties()
     {

--- a/Sami/Tests/Parser/DocBlockParserTest.php
+++ b/Sami/Tests/Parser/DocBlockParserTest.php
@@ -11,10 +11,11 @@
 
 namespace Sami\Tests\Parser;
 
+use PHPUnit\Framework\TestCase;
 use Sami\Parser\DocBlockParser;
 use Sami\Parser\Node\DocBlockNode;
 
-class DocBlockParserTest extends \PHPUnit_Framework_TestCase
+class DocBlockParserTest extends TestCase
 {
     /**
      * @dataProvider getParseTests

--- a/Sami/Tests/Parser/NodeVisitorTest.php
+++ b/Sami/Tests/Parser/NodeVisitorTest.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeTraverser;
 use PhpParser\PrettyPrinter\Standard;
+use PHPUnit\Framework\TestCase;
 use Sami\Parser\DocBlockParser;
 use Sami\Parser\Filter\TrueFilter;
 use Sami\Parser\NodeVisitor;
@@ -21,7 +22,7 @@ use Sami\Store\ArrayStore;
 /**
  * @author Tomasz Struczyński <t.struczynski@gmail.com>
  */
-class NodeVisitorTest extends \PHPUnit_Framework_TestCase
+class NodeVisitorTest extends TestCase
 {
     /**
      * @dataProvider getMethodTypehints

--- a/Sami/Tests/Parser/ParserContextTest.php
+++ b/Sami/Tests/Parser/ParserContextTest.php
@@ -3,12 +3,13 @@
 namespace Sami\Tests\Parser;
 
 use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
+use PHPUnit\Framework\TestCase;
 use Sami\Parser\DocBlockParser;
 use Sami\Parser\Filter\TrueFilter;
 use Sami\Parser\ParserContext;
 use Sami\Reflection\ClassReflection;
 
-class ParserContextTest extends \PHPUnit_Framework_TestCase
+class ParserContextTest extends TestCase
 {
     public function testLeaveClassBeforeEnter()
     {

--- a/Sami/Tests/ProjectTest.php
+++ b/Sami/Tests/ProjectTest.php
@@ -2,12 +2,13 @@
 
 namespace Sami\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Sami\Project;
 use Sami\Reflection\ClassReflection;
 use Sami\Store\ArrayStore;
 use Sami\Version\Version;
 
-class ProjectTest extends \PHPUnit_Framework_TestCase
+class ProjectTest extends TestCase
 {
     public function testSwitchVersion()
     {

--- a/Sami/Tests/Reflection/ClassReflectionTest.php
+++ b/Sami/Tests/Reflection/ClassReflectionTest.php
@@ -2,9 +2,10 @@
 
 namespace Sami\Tests\Reflection;
 
+use PHPUnit\Framework\TestCase;
 use Sami\Reflection\ClassReflection;
 
-class ClassReflectionTest extends \PHPUnit_Framework_TestCase
+class ClassReflectionTest extends TestCase
 {
     public function testIsPhpClass()
     {

--- a/Sami/Tests/Reflection/MethodReflectionTest.php
+++ b/Sami/Tests/Reflection/MethodReflectionTest.php
@@ -2,9 +2,10 @@
 
 namespace Sami\Tests\Reflection;
 
+use PHPUnit\Framework\TestCase;
 use Sami\Reflection\MethodReflection;
 
-class MethodReflectionTest extends \PHPUnit_Framework_TestCase
+class MethodReflectionTest extends TestCase
 {
     public function testSetGetModifiers()
     {

--- a/Sami/Tests/Reflection/PropertyReflectionTest.php
+++ b/Sami/Tests/Reflection/PropertyReflectionTest.php
@@ -2,9 +2,10 @@
 
 namespace Sami\Tests\Reflection;
 
+use PHPUnit\Framework\TestCase;
 use Sami\Reflection\PropertyReflection;
 
-class PropertyReflectionTest extends \PHPUnit_Framework_TestCase
+class PropertyReflectionTest extends TestCase
 {
     public function testSetGetModifiers()
     {

--- a/Sami/Tests/TreeTest.php
+++ b/Sami/Tests/TreeTest.php
@@ -2,6 +2,7 @@
 
 namespace Sami\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Sami\Project;
 use Sami\Reflection\ClassReflection;
 use Sami\Store\ArrayStore;
@@ -10,7 +11,7 @@ use Sami\Tree;
 /**
  * @author Tomasz Struczyński <t.struczynski@gmail.com>
  */
-class TreeTest extends \PHPUnit_Framework_TestCase
+class TreeTest extends TestCase
 {
     public function testNamespaces()
     {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "blackfire/php-sdk": "^1.5.18"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "~3.2"
+        "symfony/phpunit-bridge": "~4.0"
     },
     "autoload": {
         "psr-4": { "Sami\\": "Sami/" }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3fa9a56e24192f57b468ef52ad602644",
+    "content-hash": "55f7d9aa9d6b34a6e0dd3c43af16fe87",
     "packages": [
         {
             "name": "blackfire/php-sdk",
@@ -810,22 +810,26 @@
     "packages-dev": [
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.2.1",
+            "version": "v4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "65e64a4f99cbaeae718573c3347fbe800f3f6661"
+                "reference": "65fb01d93337b8e592790ba34556bfb0c0bbdd5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/65e64a4f99cbaeae718573c3347fbe800f3f6661",
-                "reference": "65e64a4f99cbaeae718573c3347fbe800f3f6661",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/65fb01d93337b8e592790ba34556bfb0c0bbdd5f",
+                "reference": "65fb01d93337b8e592790ba34556bfb0c0bbdd5f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
+            },
             "suggest": {
+                "ext-zip": "Zip support is required when using bin/simple-phpunit",
                 "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
             },
             "bin": [
@@ -834,7 +838,7 @@
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -864,7 +868,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2016-12-12T13:31:08+00:00"
+            "time": "2017-12-04T20:23:32+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to update `symfony/phpunit-bridge` to support this `namespace`.