### PR TITLE
BUG Correct cache pollution between versions

### DIFF
--- a/Sami/Project.php
+++ b/Sami/Project.php
@@ -104,16 +104,10 @@ class Project
 
     public function update($callback = null, $force = false)
     {
-        $previousParse = null;
-        $previousRender = null;
         foreach ($this->versions as $version) {
             $this->switchVersion($version, $callback, $force);
-
-            $this->parseVersion($version, $previousParse, $callback, $force);
-            $this->renderVersion($version, $previousRender, $callback, $force);
-
-            $previousParse = $this->getCacheDir();
-            $previousRender = $this->getBuildDir();
+            $this->parseVersion($version, null, $callback, $force);
+            $this->renderVersion($version, null, $callback, $force);
         }
     }
 
@@ -149,6 +143,8 @@ class Project
         }
 
         $this->version = $version;
+
+        $this->initialize();
 
         if (!$force) {
             $this->read();
@@ -245,7 +241,7 @@ class Project
 
         foreach ($this->namespaces as $sub) {
             if (substr($sub, 0, $len) == $prefix
-                && strpos(substr($sub, $len), '\\') === false
+                && false === strpos(substr($sub, $len), '\\')
             ) {
                 $namespaces[] = $sub;
             }
@@ -437,7 +433,7 @@ class Project
             $samiVersion = file_get_contents($dir.'/SAMI_VERSION');
         }
 
-        if ($samiVersion !== Sami::VERSION) {
+        if (Sami::VERSION !== $samiVersion) {
             $this->flushDir($dir);
         }
 
@@ -503,7 +499,7 @@ class Project
             return;
         }
 
-        if (strpos($root, 'github') !== false) {
+        if (false !== strpos($root, 'github')) {
             return $root.'/tree/'.$this->version;
         }
     }

--- a/Sami/Renderer/Renderer.php
+++ b/Sami/Renderer/Renderer.php
@@ -35,7 +35,7 @@ class Renderer
         $this->twig = $twig;
         $this->themes = $themes;
         $this->tree = $tree;
-        $this->cachedTree = new \SplObjectStorage();
+        $this->cachedTree = array();
         $this->indexer = $indexer;
         $this->filesystem = new Filesystem();
     }
@@ -227,12 +227,20 @@ class Renderer
         return floor((++$this->step / $this->steps) * 100);
     }
 
+    /**
+     * Get tree for the given project.
+     *
+     * @param Project $project
+     *
+     * @return array
+     */
     private function getTree(Project $project)
     {
-        if (!isset($this->cachedTree[$project])) {
-            $this->cachedTree[$project] = $this->tree->getTree($project);
+        $key = $project->getVersion()->getName();
+        if (!isset($this->cachedTree[$key])) {
+            $this->cachedTree[$key] = $this->tree->getTree($project);
         }
 
-        return $this->cachedTree[$project];
+        return $this->cachedTree[$key];
     }
 }

--- a/Sami/Renderer/Renderer.php
+++ b/Sami/Renderer/Renderer.php
@@ -236,7 +236,7 @@ class Renderer
      */
     private function getTree(Project $project)
     {
-        $key = $project->getVersion()->getName();
+        $key = $project->getBuildDir();
         if (!isset($this->cachedTree[$key])) {
             $this->cachedTree[$key] = $this->tree->getTree($project);
         }

--- a/Sami/Tests/ProjectTest.php
+++ b/Sami/Tests/ProjectTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Sami\Tests;
+
+use Sami\Project;
+use Sami\Reflection\ClassReflection;
+use Sami\Store\ArrayStore;
+use Sami\Version\Version;
+
+class ProjectTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSwitchVersion()
+    {
+        // Dummy store and classes
+        $class1 = new ClassReflection('C1', 1);
+        $class2 = new ClassReflection('C21\\C2', 1);
+        $class3 = new ClassReflection('C31\\C32\\C3', 1);
+        $class2->setNamespace('C21');
+        $class3->setNamespace('C31\\C32');
+        $store = new ArrayStore();
+        $store->setClasses(array($class1, $class2, $class3));
+        $project = new Project($store);
+
+        // Load version 1
+        $project->switchVersion(new Version('1'), null, true);
+
+        $project->loadClass('C1');
+        $project->loadClass('C21\\C2');
+
+        $this->assertEquals(
+            array(
+                'C1' => $class1,
+                'C21\\C2' => $class2,
+            ),
+            $project->getProjectClasses()
+        );
+
+        // Load version 2
+        $project->switchVersion(new Version('2'), null, true);
+        $project->loadClass($class2);
+        $project->loadClass($class3);
+
+        $this->assertEquals(
+            array(
+                'C21\\C2' => $class2,
+                'C31\\C32\\C3' => $class3,
+             ),
+            $project->getProjectClasses()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #62 (four year old bug :) )

I appreciate critique regarding the removal of the cache warming between versions; My experience is that the error in the output outweigh the performance benefit, but I stand to be corrected if possible. :)

Possibly there is another caching warming / reuse pattern that could be replaced, but I'm not familiar enough with the design to implement one I'm afraid.

I had some issue with ArrayStore not respecting the project version, but out of respect I've opted not to try to shiv in a fix for it.

