### PR TITLE
Implement option to sort properties, methods, constants, traits and interfaces

### DIFF
--- a/Sami/Reflection/ClassReflection.php
+++ b/Sami/Reflection/ClassReflection.php
@@ -557,7 +557,7 @@ class ClassReflection extends Reflection
 
     public function isInterface()
     {
-        return $this->category === self::CATEGORY_INTERFACE;
+        return self::CATEGORY_INTERFACE === $this->category;
     }
 
     public function setTrait($boolean)
@@ -567,7 +567,7 @@ class ClassReflection extends Reflection
 
     public function isTrait()
     {
-        return $this->category === self::CATEGORY_TRAIT;
+        return self::CATEGORY_TRAIT === $this->category;
     }
 
     public function setCategory($category)
@@ -694,7 +694,7 @@ class ClassReflection extends Reflection
 
     public function sortInterfaces($sort)
     {
-       if (is_callable($sort)) {
+        if (is_callable($sort)) {
             uksort($this->interfaces, $sort);
         } else {
             ksort($this->interfaces);

--- a/Sami/Reflection/ClassReflection.php
+++ b/Sami/Reflection/ClassReflection.php
@@ -691,4 +691,15 @@ class ClassReflection extends Reflection
     {
         return self::$categoryName[$this->category];
     }
+
+    public function sortInterfaces($sort)
+    {
+        if ($sort) {
+           if (is_callable($sort)) {
+                uksort($this->interfaces, $sort);
+            } else {
+                ksort($this->interfaces);
+            } 
+        }
+    }
 }

--- a/Sami/Reflection/ClassReflection.php
+++ b/Sami/Reflection/ClassReflection.php
@@ -694,12 +694,10 @@ class ClassReflection extends Reflection
 
     public function sortInterfaces($sort)
     {
-        if ($sort) {
-           if (is_callable($sort)) {
-                uksort($this->interfaces, $sort);
-            } else {
-                ksort($this->interfaces);
-            } 
+       if (is_callable($sort)) {
+            uksort($this->interfaces, $sort);
+        } else {
+            ksort($this->interfaces);
         }
     }
 }

--- a/Sami/Renderer/Renderer.php
+++ b/Sami/Renderer/Renderer.php
@@ -163,8 +163,8 @@ class Renderer
             $properties = $class->getProperties($project->getConfig('include_parent_data'));
 
             $sortProperties = $project->getConfig('sort_class_properties');
-            if($sortProperties) {
-                if(is_callable($sortProperties)) {
+            if ($sortProperties) {
+                if (is_callable($sortProperties)) {
                     uksort($properties, $sortProperties);
                 } else {
                     ksort($properties);
@@ -174,8 +174,8 @@ class Renderer
             $methods = $class->getMethods($project->getConfig('include_parent_data'));
 
             $sortMethods = $project->getConfig('sort_class_methods');
-            if($sortMethods) {
-                if(is_callable($sortMethods)) {
+            if ($sortMethods) {
+                if (is_callable($sortMethods)) {
                     uksort($methods, $sortMethods);
                 } else {
                     ksort($methods);
@@ -185,8 +185,8 @@ class Renderer
             $constants = $class->getConstants($project->getConfig('include_parent_data'));
 
             $sortConstants = $project->getConfig('sort_class_constants');
-            if($sortConstants) {
-                if(is_callable($sortConstants)) {
+            if ($sortConstants) {
+                if (is_callable($sortConstants)) {
                     uksort($constants, $sortConstants);
                 } else {
                     ksort($constants);
@@ -196,8 +196,8 @@ class Renderer
             $traits = $class->getTraits($project->getConfig('include_parent_data'));
 
             $sortTraits = $project->getConfig('sort_class_traits');
-            if($sortTraits) {
-                if(is_callable($sortTraits)) {
+            if ($sortTraits) {
+                if (is_callable($sortTraits)) {
                     uksort($traits, $sortTraits);
                 } else {
                     ksort($traits);

--- a/Sami/Renderer/Renderer.php
+++ b/Sami/Renderer/Renderer.php
@@ -204,6 +204,11 @@ class Renderer
                 }
             }
 
+            $sortInterfaces = $project->getConfig('sort_class_interfaces');
+            if ($sortInterfaces) {
+                $class->sortInterfaces($sortInterfaces);
+            }
+
             $variables = array(
                 'class' => $class,
                 'properties' => $properties,

--- a/Sami/Renderer/Renderer.php
+++ b/Sami/Renderer/Renderer.php
@@ -160,12 +160,56 @@ class Renderer
                 call_user_func($callback, Message::RENDER_PROGRESS, array('Class', $class->getName(), $this->getProgression()));
             }
 
+            $properties = $class->getProperties($project->getConfig('include_parent_data'));
+
+            $sortProperties = $project->getConfig('sort_class_properties');
+            if($sortProperties) {
+                if(is_callable($sortProperties)) {
+                    uksort($properties, $sortProperties);
+                } else {
+                    ksort($properties);
+                }
+            }
+  
+            $methods = $class->getMethods($project->getConfig('include_parent_data'));
+
+            $sortMethods = $project->getConfig('sort_class_methods');
+            if($sortMethods) {
+                if(is_callable($sortMethods)) {
+                    uksort($methods, $sortMethods);
+                } else {
+                    ksort($methods);
+                }
+            }
+
+            $constants = $class->getConstants($project->getConfig('include_parent_data'));
+
+            $sortConstants = $project->getConfig('sort_class_constants');
+            if($sortConstants) {
+                if(is_callable($sortConstants)) {
+                    uksort($constants, $sortConstants);
+                } else {
+                    ksort($constants);
+                }
+            }
+
+            $traits = $class->getTraits($project->getConfig('include_parent_data'));
+
+            $sortTraits = $project->getConfig('sort_class_traits');
+            if($sortTraits) {
+                if(is_callable($sortTraits)) {
+                    uksort($traits, $sortTraits);
+                } else {
+                    ksort($traits);
+                }
+            }
+
             $variables = array(
                 'class' => $class,
-                'properties' => $class->getProperties($project->getConfig('include_parent_data')),
-                'methods' => $class->getMethods($project->getConfig('include_parent_data')),
-                'constants' => $class->getConstants($project->getConfig('include_parent_data')),
-                'traits' => $class->getTraits($project->getConfig('include_parent_data')),
+                'properties' => $properties,
+                'methods' => $methods,
+                'constants' => $constants,
+                'traits' => $traits,
                 'tree' => $this->getTree($project),
             );
 

--- a/Sami/Renderer/Renderer.php
+++ b/Sami/Renderer/Renderer.php
@@ -170,7 +170,7 @@ class Renderer
                     ksort($properties);
                 }
             }
-  
+
             $methods = $class->getMethods($project->getConfig('include_parent_data'));
 
             $sortMethods = $project->getConfig('sort_class_methods');

--- a/Sami/Sami.php
+++ b/Sami/Sami.php
@@ -73,6 +73,11 @@ class Sami extends Container
                 'source_url' => $sc['source_url'],
                 'source_dir' => $sc['source_dir'],
                 'insert_todos' => $sc['insert_todos'],
+                'sort_class_properties' => $sc['sort_class_properties'],
+                'sort_class_methods' => $sc['sort_class_methods'],
+                'sort_class_constants' => $sc['sort_class_constants'],
+                'sort_class_traits' => $sc['sort_class_traits'],
+                'sort_class_interfaces' => $sc['sort_class_interfaces'],
             ));
             $project->setRenderer($sc['renderer']);
             $project->setParser($sc['parser']);
@@ -176,6 +181,11 @@ class Sami extends Container
         $this['source_url'] = '';
         $this['default_opened_level'] = 2;
         $this['insert_todos'] = false;
+        $this['sort_class_properties'] = false;
+        $this['sort_class_methods'] = false;
+        $this['sort_class_constants'] = false;
+        $this['sort_class_traits'] = false;
+        $this['sort_class_interfaces'] = false;
 
         // simulate namespaces for projects based on the PEAR naming conventions
         $this['simulate_namespaces'] = false;


### PR DESCRIPTION
This simple PR adds the possibility for the user to decide if the properties, methods, constants and traits get sorted on the class page. This can be done by simple defining a truthy value (`true`), to sort by lexicographical (used gets `uksort`). It's also possible to define a callable, which then gets passed to `uksort`.

New options available:
`sort_class_properties`
`sort_class_methods`
`sort_class_constants`
`sort_class_traits`
`sort_class_interfaces`

Fixes #319.