### PR TITLE
Inconsistent result on Index Page

### DIFF
--- a/Sami/Resources/themes/default/macros.twig
+++ b/Sami/Resources/themes/default/macros.twig
@@ -20,7 +20,7 @@
 
 {% macro property_link(property, absolute, classonly) -%}
     <a href="{{ property_path(property) }}">
-        {{- abbr_class(property.class) }}{% if not classonly|default(true) %}#{{ property.name|raw }}{% endif -%}
+        {{- abbr_class(property.class) }}{% if not classonly|default(false) %}#{{ property.name|raw }}{% endif -%}
     </a>
 {%- endmacro %}
 


### PR DESCRIPTION
Switches a boolean in the macro to provide, by default, a consistent result on the index page. Fixes #309.