### PR TITLE
Fix type null for nullable type parameters not added as type

### DIFF
--- a/Sami/Parser/NodeVisitor.php
+++ b/Sami/Parser/NodeVisitor.php
@@ -180,7 +180,13 @@ class NodeVisitor extends NodeVisitorAbstract
             }
 
             if (null !== $typeStr) {
-                $parameter->setHint($this->resolveHint(array(array($typeStr, false))));
+                $typeArr = array(array($typeStr, false));
+
+                if ($param->type instanceof NullableType) {
+                    $typeArr[] = array('null', false);
+                }
+
+                $parameter->setHint($this->resolveHint($typeArr));
             }
 
             $method->addParameter($parameter);


### PR DESCRIPTION
I've started using PHP 7.1 nullable types and noticed, that Sami is not able to parse them. I saw the issue #264, but it does not fix the issue, at least not for parameters.

For example `function setAvatar(?string $data)` will result in a type of `string`, and not `string|null` as expected. The PHP documentation for that element *is* `@param string|null $data`.

This PR fixes this by adding the `null` type to the type array when resolving hints.