### PR TITLE
allow `true` and `false` type-hint

### DIFF
--- a/Sami/Project.php
+++ b/Sami/Project.php
@@ -372,7 +372,7 @@ class Project
 
     public static function isPhpTypeHint($hint)
     {
-        return in_array(strtolower($hint), array('', 'scalar', 'object', 'boolean', 'bool', 'int', 'integer', 'array', 'string', 'mixed', 'void', 'null', 'resource', 'double', 'float', 'callable'));
+        return in_array(strtolower($hint), array('', 'scalar', 'object', 'boolean', 'bool', 'true', 'false', 'int', 'integer', 'array', 'string', 'mixed', 'void', 'null', 'resource', 'double', 'float', 'callable'));
     }
 
     protected function updateCache(ClassReflection $class)


### PR DESCRIPTION
thus removing weird `abbr` titles such as `my\namespaced\class\false`