### PR TITLE
Removed use of ProcessBuilder

### DIFF
--- a/Sami/Version/GitVersionCollection.php
+++ b/Sami/Version/GitVersionCollection.php
@@ -13,7 +13,6 @@ namespace Sami\Version;
 
 use Symfony\Component\Finder\Glob;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessBuilder;
 
 class GitVersionCollection extends VersionCollection
 {
@@ -105,9 +104,7 @@ class GitVersionCollection extends VersionCollection
     {
         array_unshift($arguments, $this->gitPath);
 
-        $builder = new ProcessBuilder($arguments);
-        $builder->setWorkingDirectory($this->repo);
-        $process = $builder->getProcess();
+        $process = new Process($arguments, $this->repo);
         $process->run();
 
         if (!$process->isSuccessful()) {


### PR DESCRIPTION
Hello,

Version 4.1 of Sami is currently not working when using `GitVersionCollection`, because it relies on `Symfony\Component\Process\ProcessBuilder`, which has been removed in version 4 of `symfony/process`.

Version 4.0 of Sami pointed to version `~3.0` of `symfony/process`, so that works regularly. According to the Symfony upgrade guide, instead of relying on `ProcessBuilder`, we just use `Process` directly.

The Phar at `http://get.sensiolabs.org/sami.phar` is affected, so it might be breaking some CI builds (that's how I discovered about this).