### PR TITLE
Allow $this type hint

### DIFF
--- a/Sami/Project.php
+++ b/Sami/Project.php
@@ -372,7 +372,7 @@ class Project
 
     public static function isPhpTypeHint($hint)
     {
-        return in_array(strtolower($hint), array('', 'scalar', 'object', 'boolean', 'bool', 'true', 'false', 'int', 'integer', 'array', 'string', 'mixed', 'void', 'null', 'resource', 'double', 'float', 'callable'));
+        return in_array(strtolower($hint), array('', 'scalar', 'object', 'boolean', 'bool', 'true', 'false', 'int', 'integer', 'array', 'string', 'mixed', 'void', 'null', 'resource', 'double', 'float', 'callable', '$this'));
     }
 
     protected function updateCache(ClassReflection $class)


### PR DESCRIPTION
This PR allows the `$this` type hint (use case: return type). This removes the absurd cases of `\MyNamespace\$this` in the documentation.